### PR TITLE
Adding time-grunt to report grunt task build times

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,9 @@
 module.exports = function(grunt) {
+  require('time-grunt')(grunt);
+
   // load all grunt tasks matching the `grunt-*` pattern
   require('load-grunt-tasks')(grunt);
+
   // load the Intern tasks
   grunt.loadNpmTasks('intern');
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "bower": "~1.2.7",
     "grunt-bytesize": "~0.1.1",
-    "intern": "~1.2.1"
+    "intern": "~1.2.1",
+    "time-grunt": "~0.1.2"
   }
 }


### PR DESCRIPTION
Simple logger that reports timing metrics for each grunt task. This can help us track if certain tasks start taking longer times to complete.

```
Done, without errors.

Elapsed time
loading tasks    257ms
jshint:config    32ms
requirejs:prod   291ms
requirejs:debug  36ms
bytesize:all     9ms
Total            625ms
```
