### PR TITLE
Adding Sauce Labs testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /build
 /components
+sauce_connect.log*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,20 @@
 language: node_js
+
+env:
+  global:
+    # Sauce Labs are OK with this and it is currently necessary to expose this information for testing pull requests;
+    # please get your own free key if you want to test yourself
+    - SAUCE_USERNAME: gherkin-web
+    - SAUCE_ACCESS_KEY: de4982ac-cb05-4b9c-8059-385a83de8af4
+
+notifications:
+  irc:
+    channels:
+      - "irc.mozilla.org#fxa"
+    use_notice: false
+    skip_join: false
+
 node_js:
   - "0.10"
+
+script: grunt intern

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,6 +75,15 @@ module.exports = function(grunt) {
           reporters: ['console'],
           suites: ['tests/all']
         }
+      },
+      browser: {
+        options: {
+          runType: 'runner',
+          config: 'tests/intern_sauce',
+          suites: ['tests/all'],
+          sauceUsername: "gherkin-web",
+          sauceAccessKey: "de4982ac-cb05-4b9c-8059-385a83de8af4"
+        }
       }
     }
   });

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -2,34 +2,14 @@
 // These default settings work OK for most people. The options that *must* be changed below are the
 // packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
 define({
-  proxyPort: 9000,
-  proxyUrl: 'http://localhost:9000/',
-  capabilities: {
-    'selenium-version': '2.35.0'
-  },
-  environments: [
-    { browserName: 'firefox', version: '23', platform: [ 'Linux', 'Windows 7' ] },
-    { browserName: 'chrome', platform: [ 'Linux', 'Mac 10.8', 'Windows 7' ] },
-    { browserName: 'safari', version: '6', platform: 'Mac 10.8' }
-  ],
-  maxConcurrency: 3,
-  useSauceConnect: true,
-
-  // Connection information for the remote WebDriver service. If using Sauce Labs, keep your username and password
-  // in the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables unless you are sure you will NEVER be
-  // publishing this configuration file somewhere
-  webdriver: {
-    host: 'localhost',
-    port: 4444
-  },
 
   loader: {
     // Packages that should be registered with the loader in each testing environment
     packages: [ { name: 'gherkin', location: 'gherkin' } ]
   },
 
-  suites: [ 'tests/main' ],
-  functionalSuites: [ /* 'myPackage/tests/functional' */ ],
+  suites: [ 'tests/all' ],
+  functionalSuites: [ ],
 
   // A regular expression matching URLs to files that should not be included in code coverage analysis
   excludeInstrumentation: /^tests\//

--- a/tests/intern_sauce.js
+++ b/tests/intern_sauce.js
@@ -1,0 +1,22 @@
+define([
+  './intern'
+], function (intern) {
+  intern.useSauceConnect = true;
+  intern.maxConcurrency = 3;
+
+  intern.webdriver =  {
+    host: 'localhost',
+    port: 4445
+  };
+
+  intern.capabilities = {
+    'selenium-version': '2.37.0'
+  };
+
+  intern.environments = [
+    { browserName: 'firefox', version: '24' , platform: [ 'Windows 7', 'Linux' ] },
+    { browserName: 'internet explorer', version: '10', platform: [ 'Windows 8', 'Windows 7' ] }
+  ];
+
+  return intern;
+});


### PR DESCRIPTION
Current testing environments: 

```
{ browserName: 'firefox', version: '24' , platform: [ 'Windows 7', 'Linux' ] },
{ browserName: 'internet explorer', version: '10', platform: [ 'Windows 8', 'Windows 7' ] }
```

`npm test` still runs the tests via node only. However Sauce Labs tests run via Travis CI.
