### PR TITLE
Adding missing copyrights

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,8 @@
-module.exports = function(grunt) {
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
   // load all grunt tasks matching the `grunt-*` pattern
   require('load-grunt-tasks')(grunt);
   // load the Intern tasks

--- a/tasks/sjcl.js
+++ b/tasks/sjcl.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 module.exports = function (grunt) {
   var fs = require('fs');
   var exec = require('child_process').exec;

--- a/tests/addons/sinonResponder.js
+++ b/tests/addons/sinonResponder.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   'tests/addons/sinon'
 ], function (Sinon) {

--- a/tests/all.js
+++ b/tests/all.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   'tests/lib/main',
   'tests/lib/request',

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
 // These default settings work OK for most people. The options that *must* be changed below are the
 // packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.

--- a/tests/intern_browser.js
+++ b/tests/intern_browser.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   './intern'
 ], function (intern) {

--- a/tests/intern_sauce.js
+++ b/tests/intern_sauce.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   './intern'
 ], function (intern) {

--- a/tests/lib/credentials.js
+++ b/tests/lib/credentials.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   'intern!tdd',
   'intern/chai!assert',

--- a/tests/lib/hawkCredentials.js
+++ b/tests/lib/hawkCredentials.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   'intern!tdd',
   'intern/chai!assert',

--- a/tests/lib/hkdf.js
+++ b/tests/lib/hkdf.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   'intern!tdd',
   'intern/chai!assert',

--- a/tests/lib/main.js
+++ b/tests/lib/main.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   'intern!tdd',
   'intern/chai!assert',

--- a/tests/lib/request.js
+++ b/tests/lib/request.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 define([
   'intern!tdd',
   'intern/chai!assert',

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -1,4 +1,8 @@
-define([], function () {
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ define([], function () {
   return {
     signUp: {
       status: 200,


### PR DESCRIPTION
This covers most of the results from Issue mozilla/fxa-js-client#37 with the exception of the following:
- build/fxa-client.min.js (this is generated and minified -- we may need to solve this w/ uglify or something else)
- tests/addons/sinon.js (3rd party, so I should exclude this file from the results and upcoming Grunt task)
