### PR TITLE
Add incorrect case error handling for 3 routes

### DIFF
--- a/tests/addons/sinonResponder.js
+++ b/tests/addons/sinonResponder.js
@@ -16,7 +16,7 @@ define([
       return function (returnValue, response) {
         setTimeout(function () {
           self.respond(requests[requestIndex++], response);
-        }, 10);
+        }, 100);
 
         return returnValue;
       }

--- a/tests/all.js
+++ b/tests/all.js
@@ -3,13 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
+  'tests/lib/signUp',
+  'tests/lib/signIn',
   'tests/lib/main',
   'tests/lib/request',
   'tests/lib/hkdf',
   'tests/lib/credentials',
   'tests/lib/hawkCredentials',
   'tests/lib/passwordChange',
-  'tests/lib/keys',
   'tests/lib/devices',
   'tests/lib/sessionDestroy',
   'tests/lib/certificateSign',

--- a/tests/lib/hawkCredentials.js
+++ b/tests/lib/hawkCredentials.js
@@ -9,7 +9,7 @@ define([
   'client/lib/hawkCredentials'
 ], function (tdd, assert, sjcl, hawkCredentials) {
   with (tdd) {
-    suite('client hawkCredentials', function () {
+    suite('hawkCredentials', function () {
       test('#client derive hawk credentials', function () {
         var context = 'sessionToken';
         var sessionToken = 'a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf';

--- a/tests/lib/hkdf.js
+++ b/tests/lib/hkdf.js
@@ -13,7 +13,7 @@ define([
     // test vectors from RFC5869
     suite('hkdf', function () {
 
-      test('#hkdf vector 1', function () {
+      test('#vector 1', function () {
 
         var ikm = sjcl.codec.hex.toBits('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b');
         var salt = sjcl.codec.hex.toBits('000102030405060708090a0b0c');
@@ -26,7 +26,7 @@ define([
           });
       });
 
-      test('#hkdf vector 2', function () {
+      test('#vector 2', function () {
 
         var ikm = sjcl.codec.hex.toBits('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b');
         var salt = sjcl.codec.hex.toBits('');

--- a/tests/lib/main.js
+++ b/tests/lib/main.js
@@ -45,42 +45,6 @@ define([
       });
 
       /**
-       * Sign In
-       */
-      test('#sign in', function () {
-        var email = "test" + Date.now() + "@restmail.net";
-        var password = "iliketurtles";
-
-        return respond(client.signUp(email, password), RequestMocks.signUp)
-          .then(function () {
-
-            return respond(client.signIn(email, password), RequestMocks.signIn);
-          })
-          .then(function (res) {
-            assert.ok(res.sessionToken);
-          });
-      });
-
-      /**
-       * Sign In with Keys
-       */
-      test('#sign in with keys', function () {
-        var email = "test" + Date.now() + "@restmail.net";
-        var password = "iliketurtles";
-
-        return respond(client.signUp(email, password), RequestMocks.signUp)
-          .then(function (res) {
-            return respond(client.signIn(email, password, {keys: true}), RequestMocks.signInWithKeys);
-          })
-          .then(function (res) {
-            assert.ok(res.sessionToken);
-            assert.ok(res.keyFetchToken);
-            assert.ok(res.unwrapBKey);
-            return true;
-          });
-      });
-
-      /**
        * Verify Email
        */
       test('#verify email', function () {
@@ -150,51 +114,6 @@ define([
             return true;
           })
       });
-
-      /**
-       * Password Reset
-       */
-      test('#reset password', function () {
-        var user = 'test5' + Date.now();
-        var email = user + '@restmail.net';
-        var password = 'iliketurtles';
-        var uid;
-        var passwordForgotToken;
-        var accountResetToken;
-
-        return respond(client.signUp(email, password), RequestMocks.signUp)
-          .then(function (result) {
-            uid = result.uid;
-            assert.ok(uid, "uid is returned");
-
-            return respond(client.passwordForgotSendCode(email), RequestMocks.passwordForgotSendCode);
-          })
-          .then(function (result) {
-            passwordForgotToken = result.passwordForgotToken;
-            assert.ok(passwordForgotToken, "passwordForgotToken is returned");
-
-            return respond(mail.wait(user, 2), RequestMocks.resetMail);
-          })
-          .then(function (emails) {
-            var code = emails[1].html.match(/code=([A-Za-z0-9]+)/)[1];
-            assert.ok(code, "code is returned: " + code);
-
-            return respond(client.passwordForgotVerifyCode(code, passwordForgotToken), RequestMocks.passwordForgotVerifyCode);
-          })
-          .then(function (result) {
-            accountResetToken = result.accountResetToken;
-            var newPassword = 'newturles';
-            assert.ok(accountResetToken, "accountResetToken is returned");
-
-            return respond(client.accountReset(email, newPassword, accountResetToken), RequestMocks.accountReset);
-          })
-          .then(function (result) {
-            assert.ok(result, '{}');
-            return true;
-          })
-      });
-
-
     });
   }
 });

--- a/tests/lib/signUp.js
+++ b/tests/lib/signUp.js
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'tests/intern',
+  'intern!tdd',
+  'intern/chai!assert',
+  'client/FxAccountClient',
+  'intern/node_modules/dojo/has!host-node?intern/node_modules/dojo/node!xmlhttprequest',
+  'tests/addons/sinonResponder',
+  'tests/mocks/request',
+  'tests/addons/restmail',
+  'tests/addons/accountHelper'
+], function (config, tdd, assert, FxAccountClient, XHR, SinonResponder, RequestMocks, Restmail, AccountHelper) {
+
+  with (tdd) {
+    suite('signUp', function () {
+      var authServerUrl = config.AUTH_SERVER_URL || 'http://127.0.0.1:9000/v1';
+      var useRemoteServer = !!config.AUTH_SERVER_URL;
+      var mailServerUrl = authServerUrl.match(/^http:\/\/127/) ?
+        'http://127.0.0.1:9001' :
+        'http://restmail.net';
+      var client;
+      var respond;
+      var mail;
+      var accountHelper;
+
+      function noop(val) { return val; }
+
+      beforeEach(function () {
+        var xhr;
+
+        if (useRemoteServer) {
+          xhr = XHR.XMLHttpRequest;
+          respond = noop;
+        } else {
+          var requests = [];
+          xhr = SinonResponder.useFakeXMLHttpRequest();
+          xhr.onCreate = function (xhr) {
+            requests.push(xhr);
+          };
+          respond = SinonResponder.makeMockResponder(requests);
+        }
+        client = new FxAccountClient(authServerUrl, { xhr: xhr });
+        mail = new Restmail(mailServerUrl, xhr);
+        accountHelper = new AccountHelper(client, mail, respond);
+      });
+
+      /**
+       * Sign Up
+       */
+      test('#create account', function () {
+        var email = "test" + Date.now() + "@restmail.net";
+        var password = "iliketurtles";
+
+        return respond(client.signUp(email, password), RequestMocks.signUp)
+          .then(function (res) {
+            assert.property(res, 'uid', 'uid should be returned on signUp');
+            assert.property(res, 'sessionToken', 'sessionToken should be returned on signUp');
+            assert.notProperty(res, 'keyFetchToken', 'keyFetchToken should not be returned on signUp');
+          });
+      });
+
+      test('#create account with keys', function () {
+        var email = "test" + Date.now() + "@restmail.net";
+        var password = "iliketurtles";
+        var opts = {
+          keys: true
+        };
+
+        return respond(client.signUp(email, password, opts), RequestMocks.signUpKeys)
+          .then(function (res) {
+            assert.property(res, 'uid', 'uid should be returned on signUp');
+            assert.property(res, 'sessionToken', 'sessionToken should be returned on signUp');
+            assert.property(res, 'keyFetchToken', 'keyFetchToken should be returned on signUp');
+          });
+      });
+
+      test('#create account with service and redirectTo', function () {
+        var email = "test" + Date.now() + "@restmail.net";
+        var password = "iliketurtles";
+        var opts = {
+          service: 'sync',
+          redirectTo: 'https://sync.firefox.com/after_reset'
+        };
+
+        return respond(client.signUp(email, password, opts), RequestMocks.signUp)
+          .then(function (res) {
+            assert.ok(res.uid);
+          });
+      });
+
+      test('#create account with service', function () {
+        var email = "test" + Date.now() + "@restmail.net";
+        var password = "iliketurtles";
+        var opts = {
+          service: 'sync'
+        };
+
+        return respond(client.signUp(email, password, opts), RequestMocks.signUp)
+          .then(function (res) {
+            assert.ok(res.uid);
+          });
+      });
+
+      test('#create account with redirectTo', function () {
+        var email = "test" + Date.now() + "@restmail.net";
+        var password = "iliketurtles";
+        var opts = {
+          service: 'sync'
+        };
+
+        return respond(client.signUp(email, password, opts), RequestMocks.signUp)
+          .then(function (res) {
+            assert.ok(res.uid);
+          });
+      });
+
+      test('#create account emailVerified', function () {
+        var email = "test" + Date.now() + "@restmail.net";
+        var password = "iliketurtles";
+        var opts = {
+          preVerified: true
+        };
+
+        return respond(client.signUp(email, password, opts), RequestMocks.signUp)
+          .then(function (res) {
+            assert.ok(res.uid);
+
+            return respond(client.signIn(email, password), RequestMocks.signIn);
+          })
+          .then(function(res) {
+            assert.equal(res.verified, true, '== account is verified');
+          });
+      });
+
+    });
+  }
+});

--- a/tests/lib/timeOffset.js
+++ b/tests/lib/timeOffset.js
@@ -17,7 +17,7 @@ define([
 ], function (config, tdd, assert, FxAccountClient, XHR, SinonResponder, RequestMocks, Restmail, AccountHelper, Request, hawkCredentials) {
 
   with (tdd) {
-    suite('fxa client', function () {
+    suite('timeOffset', function () {
       var authServerUrl = config.AUTH_SERVER_URL || 'http://127.0.0.1:9000/v1';
       var useRemoteServer = !!config.AUTH_SERVER_URL;
       var mailServerUrl = authServerUrl.match(/^http:\/\/127/) ?
@@ -27,6 +27,7 @@ define([
       var respond;
       var xhr;
       var sessionToken;
+      var accountHelper;
 
       function noop(val) { return val; }
 


### PR DESCRIPTION
- Add incorrect case error handling for /account/create /account/destroy and /password/change/start
- Move more tests out of main.js, creates signIn.js and signUp.js test files because those have too many cases for account.js
- Fixes #58
