### PR TITLE
use serverTime from error response to correct timeskew

### DIFF
--- a/client/lib/request.js
+++ b/client/lib/request.js
@@ -52,8 +52,8 @@ define(['./hawk', '../../components/p/p', './errors'], function (hawk, p, ERRORS
       if (result.error) {
         // Try to recover from a timeskew error
         if (result.errno === ERRORS.INVALID_TIMESTAMP && !retrying) {
-          var serverTime = Date.parse(xhr.getResponseHeader('Date'));
-          self._localtimeOffsetMsec = serverTime - new Date();
+          var serverTime = result.serverTime;
+          self._localtimeOffsetMsec = (serverTime * 1000) - new Date().getTime();
           return self.send(path, method, credentials, jsonPayload, true)
             .then(deferred.resolve, deferred.reject);
 

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -103,7 +103,7 @@ define(['client/lib/errors'], function (ERRORS) {
     },
     invalidTimestamp: {
       status: 401,
-      body: '{ "errno": ' + ERRORS.INVALID_TIMESTAMP + ', "error": "Invalid authentication timestamp" }'
+      body: '{ "errno": ' + ERRORS.INVALID_TIMESTAMP + ', "error": "Invalid authentication timestamp", "serverTime": ' + new Date().getTime() + ' }'
     }
   };
 });


### PR DESCRIPTION
I feel better about using the designated response value. _Maybe_ it will help with the travis-ci issues on the content-server.
