### PR TITLE
Use named requirejs dependencies instead of paths

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-define(['./lib/request', '../components/sjcl/sjcl', './lib/credentials', './lib/hawkCredentials', './lib/errors'], function (Request, sjcl, credentials, hawkCredentials, ERRORS) {
+define(['./lib/request', 'sjcl', './lib/credentials', './lib/hawkCredentials', './lib/errors'], function (Request, sjcl, credentials, hawkCredentials, ERRORS) {
   'use strict';
 
   /**

--- a/client/lib/credentials.js
+++ b/client/lib/credentials.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-define(['./request', '../../components/sjcl/sjcl', '../../components/p/p', './hkdf', './pbkdf2'], function (Request, sjcl, P, hkdf, pbkdf2) {
+define(['./request', 'sjcl', 'p', './hkdf', './pbkdf2'], function (Request, sjcl, P, hkdf, pbkdf2) {
   'use strict';
 
   // Key wrapping and stretching configuration.

--- a/client/lib/hawk.js
+++ b/client/lib/hawk.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-define(['../../components/sjcl/sjcl'], function (sjcl) {
+define(['sjcl'], function (sjcl) {
   'use strict';
 
   /*

--- a/client/lib/hawkCredentials.js
+++ b/client/lib/hawkCredentials.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-define(['../../components/sjcl/sjcl', './hkdf'], function (sjcl, hkdf) {
+define(['sjcl', './hkdf'], function (sjcl, hkdf) {
   'use strict';
 
   var PREFIX_NAME = 'identity.mozilla.com/picl/v1/';

--- a/client/lib/hkdf.js
+++ b/client/lib/hkdf.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-define(['../../components/sjcl/sjcl', '../../components/p/p'], function (sjcl, P) {
+define(['sjcl', 'p'], function (sjcl, P) {
   'use strict';
 
   /**

--- a/client/lib/pbkdf2.js
+++ b/client/lib/pbkdf2.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-define(['../../components/sjcl/sjcl', '../../components/p/p'], function (sjcl, P) {
+define(['sjcl', 'p'], function (sjcl, P) {
   'use strict';
 
   /**

--- a/client/lib/request.js
+++ b/client/lib/request.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-define(['./hawk', '../../components/p/p', './errors'], function (hawk, p, ERRORS) {
+define(['./hawk', 'p', './errors'], function (hawk, p, ERRORS) {
   'use strict';
   /* global XMLHttpRequest */
 

--- a/tasks/require.js
+++ b/tasks/require.js
@@ -13,6 +13,10 @@ module.exports = function (grunt) {
       wrap: {
         startFile: 'config/start.frag',
         endFile: 'config/end.frag'
+      },
+      paths: {
+        sjcl: 'components/sjcl/sjcl',
+        p: 'components/p/p'
       }
     },
     prod: {

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -32,7 +32,13 @@ define(['intern/lib/args'], function (args) {
   return {
   loader: {
     // Packages that should be registered with the loader in each testing environment
-    packages: [ { name: 'fxa-js-client', location: 'client' } ]
+    packages: [ { name: 'fxa-js-client', location: 'client' } ],
+    map: {
+      '*': {
+        sjcl: 'components/sjcl/sjcl',
+        p: 'components/p/p'
+      }
+    }
   },
 
   suites: [ 'tests/all' ],


### PR DESCRIPTION
This is an enabler for more-easily shimming these out for node - step one of #80
