### PR TITLE
Better test failure messages for unhandled errors

### DIFF
--- a/tests/lib/account.js
+++ b/tests/lib/account.js
@@ -66,9 +66,7 @@ define([
             function(keys) {
               assert.ok(keys.bundle);
             },
-            function() {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -162,9 +160,7 @@ define([
             function (result) {
               assert.isNotNull(result);
             },
-            function() {
-              assert.fail();
-            }
+            assert.notOk
           )
       });
 

--- a/tests/lib/certificateSign.js
+++ b/tests/lib/certificateSign.js
@@ -44,9 +44,7 @@ define([
             function(res) {
               assert.property(res, 'cert', 'got cert');
             },
-            function() {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/credentials.js
+++ b/tests/lib/credentials.js
@@ -25,9 +25,7 @@ define([
               assert.equal(authPW, '247b675ffb4c46310bc87e26d712153abe5e1c90ef00a4784594f97ef54f2375', '== authPW is equal');
               assert.equal(unwrapBKey, 'de6a2648b78284fcb9ffa81ba95803309cfba7af583c01a8a1a63e567234dd28', '== unwrapBkey is equal');
             },
-            function() {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/devices.js
+++ b/tests/lib/devices.js
@@ -37,9 +37,7 @@ define([
             function(res) {
               assert.property(res, 'devices');
             },
-            function() {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/hawkCredentials.js
+++ b/tests/lib/hawkCredentials.js
@@ -22,9 +22,7 @@ define([
               assert.equal(hmacKey, '9d8f22998ee7f5798b887042466b72d53e56ab0c094388bf65831f702d2febc0', '== hmacKey is equal');
               assert.equal(result.id, 'c0a29dcf46174973da1378696e4c82ae10f723cf4f4d9f75e39f4ae3851595ab', '== id is equal');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
     });

--- a/tests/lib/headerLang.js
+++ b/tests/lib/headerLang.js
@@ -43,9 +43,7 @@ define([
               assert.property(emails[0], 'headers');
               assert.equal(emails[0].headers['content-language'], 'it-CH');
             },
-            function (err) {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -74,9 +72,7 @@ define([
               assert.property(emails[1], 'headers');
               assert.equal(emails[1].headers['content-language'], 'it-CH');
             },
-            function (e) {
-              assert.fail();
-            }
+            assert.notOk
           )
       });
 
@@ -103,9 +99,7 @@ define([
               assert.property(emails[1], 'headers');
               assert.equal(emails[1].headers['content-language'], 'it-CH');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           )
       });
 

--- a/tests/lib/hkdf.js
+++ b/tests/lib/hkdf.js
@@ -25,9 +25,7 @@ define([
               assert.equal(sjcl.codec.hex.fromBits(result).length, 84);
               assert.equal(sjcl.codec.hex.fromBits(result), '3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -43,9 +41,7 @@ define([
               assert.equal(sjcl.codec.hex.fromBits(result).length, 84);
               assert.equal(sjcl.codec.hex.fromBits(result), '8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/misc.js
+++ b/tests/lib/misc.js
@@ -28,9 +28,7 @@ define([
             function(res) {
               assert.property(res, 'data');
             },
-            function() {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/passwordChange.js
+++ b/tests/lib/passwordChange.js
@@ -61,9 +61,7 @@ define([
             function (res) {
               assert.property(res, 'sessionToken');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           )
       });
 
@@ -91,9 +89,7 @@ define([
             function (res) {
               assert.property(res, 'sessionToken');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           )
       });
 

--- a/tests/lib/recoveryEmail.js
+++ b/tests/lib/recoveryEmail.js
@@ -48,9 +48,7 @@ define([
               var code = emails[1].html.match(/code=([A-Za-z0-9]+)/)[1];
               assert.ok(code, "code is returned");
             },
-            function() {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -87,9 +85,7 @@ define([
             assert.equal(service[1], 'sync', 'service is returned');
             assert.equal(redirectTo[1], 'http', 'redirectTo is returned');
           },
-          function() {
-            assert.fail();
-          }
+          assert.notOk
         );
       });
 

--- a/tests/lib/session.js
+++ b/tests/lib/session.js
@@ -34,9 +34,7 @@ define([
             function(res) {
               assert.ok(res, 'got response');
             },
-            function(error) {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/signIn.js
+++ b/tests/lib/signIn.js
@@ -38,9 +38,7 @@ define([
             function (res) {
               assert.ok(res.sessionToken);
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -58,9 +56,7 @@ define([
               assert.ok(res.keyFetchToken);
               assert.ok(res.unwrapBKey);
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -76,9 +72,7 @@ define([
             function (res) {
               assert.property(res, 'sessionToken');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/signUp.js
+++ b/tests/lib/signUp.js
@@ -38,9 +38,7 @@ define([
               assert.property(res, 'sessionToken', 'sessionToken should be returned on signUp');
               assert.notProperty(res, 'keyFetchToken', 'keyFetchToken should not be returned on signUp');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -58,9 +56,7 @@ define([
               assert.property(res, 'sessionToken', 'sessionToken should be returned on signUp');
               assert.property(res, 'keyFetchToken', 'keyFetchToken should be returned on signUp');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -89,9 +85,7 @@ define([
               assert.ok(redirectTo, 'redirectTo is returned');
 
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -116,9 +110,7 @@ define([
               assert.ok(code, 'code is returned');
               assert.ok(service, 'service is returned');
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -144,9 +136,7 @@ define([
               assert.ok(redirectTo, 'redirectTo is returned');
 
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/timeOffset.js
+++ b/tests/lib/timeOffset.js
@@ -39,9 +39,7 @@ define([
               sessionToken = account.signIn.sessionToken;
               assert.ok(sessionToken);
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -73,9 +71,7 @@ define([
             function (res) {
               assert.ok(res);
             },
-            function () {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 
@@ -86,9 +82,7 @@ define([
             function (res) {
               assert.ok(res);
             },
-            function (error) {
-              assert.fail();
-            }
+            assert.notOk
           );
       });
 

--- a/tests/lib/verifyCode.js
+++ b/tests/lib/verifyCode.js
@@ -50,9 +50,7 @@ define([
             function (result) {
               assert.ok(result);
             },
-            function (error) {
-              assert.fail();
-            }
+            assert.notOk
           )
       });
 
@@ -98,9 +96,7 @@ define([
             function (result) {
               assert.equal(result.verified, true, "Email should be verified.");
             },
-            function (error) {
-              assert.fail();
-            }
+            assert.notOk
           )
       });
     });


### PR DESCRIPTION
While working on #81 I managed to get the testsuite to run, I got a whole bunch of test failures, but the errors weren't particularly detailed:

```
>> FAIL: main - fxa client - #verifyEmail (4ms)
>> Error: assert.fail()
>> AssertionError: assert.fail()
>>     at /Users/glen/Development/Github/fxa-js-client/tests/lib/verifyCode.js:54:22
>>     at onSettled (/Users/glen/Development/Github/fxa-js-client/node_modules/p-promise/p.js:258:10)
>>     at onTick (/Users/glen/Development/Github/fxa-js-client/node_modules/p-promise/p.js:40:4)
>>     at process._tickCallback (node.js:415:13)
```

After this patch

```
FAIL: main - fxa client - #verifyEmail (3ms)
Error: expected [TypeError: Object [object Object] has no method 'update'] to be falsy
AssertionError: expected [TypeError: Object [object Object] has no method 'update'] to be falsy
```
