### PR TITLE
Adding contributors file and npm script

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+Glen Mailer
+Peter deHaan
+Shane Tomlinson
+Vlad Filippov
+vladikoff
+Zach Carter
+Zachary Carter

--- a/package.json
+++ b/package.json
@@ -7,10 +7,15 @@
   "scripts": {
     "start": "grunt",
     "test": "grunt test",
-    "setup": "npm install && bower install && grunt sjcl"
+    "setup": "npm install && bower install && grunt sjcl",
+    "contributors": "git shortlog -s | cut -c8- | sort -f > CONTRIBUTORS.md"
   },
   "main": "node/index.js",
-  "files": ["node/", "client/", "LICENSE"],
+  "files": [
+    "node/",
+    "client/",
+    "LICENSE"
+  ],
   "readmeFilename": "README.md",
   "homepage": "https://github.com/mozilla/fxa-js-client",
   "engines": {


### PR DESCRIPTION
You can generate the CONTRIBUTORS.md file by running `$ npm run contributors`.

Closes #87
