### PR TITLE
feat(client): Pass along the `resume` parameter to the auth-server

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -50,6 +50,10 @@ define(['./lib/request', 'sjcl', 'p', './lib/credentials', './lib/hawkCredential
    *   set email to be verified if possible
    *   @param {String} [options.preVerifyToken]
    *   Opaque alphanumeric token that can be used to pre-verify a user.
+   *   @param {String} [options.resume]
+   *   Opaque url-encoded string that will be included in the verification link
+   *   as a querystring parameter, useful for continuing an OAuth flow for
+   *   example.
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -90,6 +94,10 @@ define(['./lib/request', 'sjcl', 'p', './lib/credentials', './lib/hawkCredential
 
             if (options.preVerifyToken) {
               data.preVerifyToken = options.preVerifyToken;
+            }
+
+            if (options.resume) {
+              data.resume = options.resume;
             }
 
             if (options.keys) {
@@ -203,6 +211,10 @@ define(['./lib/request', 'sjcl', 'p', './lib/credentials', './lib/hawkCredential
    *   Opaque alphanumeric token to be included in verification links
    *   @param {String} [options.redirectTo]
    *   a URL that the client should be redirected to after handling the request
+   *   @param {String} [options.resume]
+   *   Opaque url-encoded string that will be included in the verification link
+   *   as a querystring parameter, useful for continuing an OAuth flow for
+   *   example.
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -221,6 +233,10 @@ define(['./lib/request', 'sjcl', 'p', './lib/credentials', './lib/hawkCredential
 
       if (options.redirectTo) {
         data.redirectTo = options.redirectTo;
+      }
+
+      if (options.resume) {
+        data.resume = options.resume;
       }
 
       if (options.lang) {
@@ -247,6 +263,10 @@ define(['./lib/request', 'sjcl', 'p', './lib/credentials', './lib/hawkCredential
    *   Opaque alphanumeric token to be included in verification links
    *   @param {String} [options.redirectTo]
    *   a URL that the client should be redirected to after handling the request
+   *   @param {String} [options.resume]
+   *   Opaque url-encoded string that will be included in the verification link
+   *   as a querystring parameter, useful for continuing an OAuth flow for
+   *   example.
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -266,6 +286,10 @@ define(['./lib/request', 'sjcl', 'p', './lib/credentials', './lib/hawkCredential
 
       if (options.redirectTo) {
         data.redirectTo = options.redirectTo;
+      }
+
+      if (options.resume) {
+        data.resume = options.resume;
       }
 
       if (options.lang) {
@@ -290,6 +314,10 @@ define(['./lib/request', 'sjcl', 'p', './lib/credentials', './lib/hawkCredential
    *   Opaque alphanumeric token to be included in verification links
    *   @param {String} [options.redirectTo]
    *   a URL that the client should be redirected to after handling the request
+   *   @param {String} [options.resume]
+   *   Opaque url-encoded string that will be included in the verification link
+   *   as a querystring parameter, useful for continuing an OAuth flow for
+   *   example.
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -311,6 +339,10 @@ define(['./lib/request', 'sjcl', 'p', './lib/credentials', './lib/hawkCredential
 
       if (options.redirectTo) {
         data.redirectTo = options.redirectTo;
+      }
+
+      if (options.resume) {
+        data.resume = options.resume;
       }
 
       if (options.lang) {

--- a/tests/lib/account.js
+++ b/tests/lib/account.js
@@ -164,11 +164,12 @@ define([
           )
       });
 
-      test('#passwordForgotSendCode with service and redirectTo', function () {
+      test('#passwordForgotSendCode with service, redirectTo, and resume', function () {
         var account;
         var opts = {
           service: 'sync',
-          redirectTo: 'https://sync.firefox.com/after_reset'
+          redirectTo: 'https://sync.firefox.com/after_reset',
+          resume: 'resumejwt'
         };
 
         return accountHelper.newVerifiedAccount()
@@ -189,19 +190,23 @@ define([
             assert.ok(service, 'service found');
             var redirectTo = emails[1].html.match(/redirectTo=([A-Za-z0-9]+)/);
             assert.ok(redirectTo, 'redirectTo found');
+            var resume = emails[1].html.match(/resume=([A-Za-z0-9]+)/);
+            assert.ok(resume, 'resume found');
 
             assert.ok(code[1], 'code is returned');
             assert.equal(service[1], 'sync', 'service is returned');
             assert.equal(redirectTo[1], 'https', 'redirectTo is returned');
+            assert.equal(resume[1], 'resumejwt', 'resume is returned');
           })
       });
 
-      test('#passwordForgotResendCode with service and redirectTo', function () {
+      test('#passwordForgotResendCode with service, redirectTo, and resume', function () {
         var account;
         var passwordForgotToken;
         var opts = {
           service: 'sync',
-          redirectTo: 'https://sync.firefox.com/after_reset'
+          redirectTo: 'https://sync.firefox.com/after_reset',
+          resume: 'resumejwt'
         };
 
         return accountHelper.newVerifiedAccount()
@@ -234,10 +239,13 @@ define([
             assert.ok(service, 'service found');
             var redirectTo = emails[2].html.match(/redirectTo=([A-Za-z0-9]+)/);
             assert.ok(redirectTo, 'redirectTo found');
+            var resume = emails[2].html.match(/resume=([A-Za-z0-9]+)/);
+            assert.ok(resume, 'resume found');
 
             assert.ok(code[1], 'code is returned');
             assert.equal(service[1], 'sync', 'service is returned');
             assert.equal(redirectTo[1], 'https', 'redirectTo is returned');
+            assert.equal(resume[1], 'resumejwt', 'resume is returned');
           })
       });
 

--- a/tests/lib/recoveryEmail.js
+++ b/tests/lib/recoveryEmail.js
@@ -52,11 +52,12 @@ define([
           );
       });
 
-      test('#recoveryEmailResendCode with service and redirectTo', function () {
+      test('#recoveryEmailResendCode with service, redirectTo, and resume', function () {
         var user;
         var opts = {
           service: 'sync',
-          redirectTo: 'https://sync.firefox.com/after_reset'
+          redirectTo: 'https://sync.firefox.com/after_reset',
+          resume: 'resumejwt'
         };
 
         return accountHelper.newUnverifiedAccount()
@@ -80,10 +81,13 @@ define([
             assert.ok(service, 'service found');
             var redirectTo = emails[1].html.match(/redirectTo=([A-Za-z0-9]+)/);
             assert.ok(redirectTo, 'redirectTo found');
+            var resume = emails[1].html.match(/resume=([A-Za-z0-9]+)/);
+            assert.ok(resume, 'resume found');
 
             assert.ok(code[1], 'code is returned');
             assert.equal(service[1], 'sync', 'service is returned');
             assert.equal(redirectTo[1], 'https', 'redirectTo is returned');
+            assert.equal(resume[1], 'resumejwt', 'resume is returned');
           },
           assert.notOk
         );

--- a/tests/lib/signUp.js
+++ b/tests/lib/signUp.js
@@ -61,13 +61,14 @@ define([
           );
       });
 
-      test('#create account with service and redirectTo', function () {
+      test('#create account with service, redirectTo, and resume', function () {
         var user = "test" + new Date().getTime();
         var email = user + "@restmail.net";
         var password = "iliketurtles";
         var opts = {
           service: 'sync',
-          redirectTo: 'https://sync.firefox.com/after_reset'
+          redirectTo: 'https://sync.firefox.com/after_reset',
+          resume: 'resumejwt'
         };
 
         return respond(client.signUp(email, password, opts), RequestMocks.signUp)
@@ -80,10 +81,12 @@ define([
               var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
               var service = emails[0].html.match(/service=([A-Za-z0-9]+)/)[1];
               var redirectTo = emails[0].html.match(/redirectTo=([A-Za-z0-9]+)/)[1];
+              var resume = emails[0].html.match(/resume=([A-Za-z0-9]+)/)[1];
 
               assert.ok(code, 'code is returned');
               assert.ok(service, 'service is returned');
               assert.ok(redirectTo, 'redirectTo is returned');
+              assert.ok(resume, 'resume is returned');
 
             },
             assert.notOk
@@ -135,6 +138,32 @@ define([
 
               assert.ok(code, 'code is returned');
               assert.ok(redirectTo, 'redirectTo is returned');
+
+            },
+            assert.notOk
+          );
+      });
+
+      test('#withResume', function () {
+        var user = "test" + new Date().getTime();
+        var email = user + "@restmail.net";
+        var password = "iliketurtles";
+        var opts = {
+          resume: 'resumejwt'
+        };
+
+        return respond(client.signUp(email, password, opts), RequestMocks.signUp)
+          .then(function (res) {
+            assert.ok(res.uid);
+            return respond(mail.wait(user), RequestMocks.mailServiceAndRedirect);
+          })
+          .then(
+            function (emails) {
+              var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
+              var resume = emails[0].html.match(/resume=([A-Za-z0-9]+)/)[1];
+
+              assert.ok(code, 'code is returned');
+              assert.ok(resume, 'resume is returned');
 
             },
             assert.notOk

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -47,7 +47,7 @@ define(['client/lib/errors'], function (ERRORS) {
     },
     mailServiceAndRedirect: {
       status: 200,
-      body: '[{"html":"Mocked code=9001 service=sync redirectTo=https"}]'
+      body: '[{"html":"Mocked code=9001 service=sync redirectTo=https resume=resumejwt"}]'
     },
     resetMail: {
       status: 200,
@@ -55,11 +55,11 @@ define(['client/lib/errors'], function (ERRORS) {
     },
     resetMailWithServiceAndRedirect: {
       status: 200,
-      body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001 service=sync redirectTo=https"}]'
+      body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001 service=sync redirectTo=https resume=resumejwt"}]'
     },
     resetMailResendWithServiceAndRedirect: {
       status: 200,
-      body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001 service=sync redirectTo=https"}, {"html":"Mocked code=9001 service=sync redirectTo=https"}]'
+      body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001 service=sync redirectTo=https"}, {"html":"Mocked code=9001 service=sync redirectTo=https resume=resumejwt"}]'
     },
     resetMailLang: {
       status: 200,


### PR DESCRIPTION
Affects `signUp`, `recoveryEmailResendCode`, `passwordForgotSendCode`, `passwordForgotResendCode`

fixes #131

Note - I did not update the response mock names for the responses that end in `ServiceAndRedirect`. I was thinking of renaming that `AllParams` or `EchoParams` or something to that effect, but was unsure.
