### PR TITLE
fix(request): return an error object when the response is an HTML error ...

### DIFF
--- a/client/lib/request.js
+++ b/client/lib/request.js
@@ -85,7 +85,7 @@ define(['./hawk', 'p', './errors'], function (hawk, P, ERRORS) {
           if (result.length === 0) {
             return deferred.reject({ error: 'Timeout error', errno: 999 });
           } else {
-            return deferred.reject(result);
+            return deferred.reject({ error: 'Unknown error', message: result, errno: 999, code: xhr.status });
           }
         }
 

--- a/tests/lib/request.js
+++ b/tests/lib/request.js
@@ -58,6 +58,20 @@ define([
           }
         );
       });
+
+      test('#bad response format error', function () {
+        request = new Request('http://example.com/', env.xhr);
+
+        // Trigger an error response that's in HTML
+        var response = env.respond(request.send("/nonexistent", "GET"), ErrorMocks.badResponseFormat);
+
+        return response.then(
+          assert.notOk,
+          function (err) {
+            assert.equal(err.error, 'Unknown error');
+          }
+        );
+      });
     });
   }
 });

--- a/tests/mocks/errors.js
+++ b/tests/mocks/errors.js
@@ -140,6 +140,11 @@ define([], function () {
       status: 400,
       headers: {},
       body: ''
+    },
+    badResponseFormat: {
+      status: 404,
+      headers: {},
+      body: '<html><body>Something is wrong.</body></html>'
     }
   };
 });


### PR DESCRIPTION
...page

This will fix https://github.com/mozilla/fxa-content-server/issues/1656

@vladikoff r?
