### PR TITLE
feat(client): Return `unwrapBKey` in `signUp` if `keys=true` is specified.

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -117,7 +117,15 @@ define([
             }
           }
 
-          return self.request.send(endpoint, 'POST', null, data, requestOpts);
+          return self.request.send(endpoint, 'POST', null, data, requestOpts)
+            .then(
+              function(accountData) {
+                if (options && options.keys) {
+                  accountData.unwrapBKey = sjcl.codec.hex.fromBits(result.unwrapBKey);
+                }
+                return accountData;
+              }
+            );
         }
       );
   };

--- a/tests/lib/signUp.js
+++ b/tests/lib/signUp.js
@@ -56,6 +56,7 @@ define([
               assert.property(res, 'uid', 'uid should be returned on signUp');
               assert.property(res, 'sessionToken', 'sessionToken should be returned on signUp');
               assert.property(res, 'keyFetchToken', 'keyFetchToken should be returned on signUp');
+              assert.property(res, 'unwrapBKey', 'unwrapBKey should be returned on signUp');
             },
             assert.notOk
           );


### PR DESCRIPTION
@zaach - mind reviewing?

fixes #135
