### PR TITLE
feat(client): Add account unlock functionality.

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -771,6 +771,78 @@ define([
     return this.request.send('/get_random_bytes', 'POST');
   };
 
+  /**
+   * Lock an account - only available in a testing environment.
+   *
+   * @method accountLock
+   * @param {String} email
+   * @param {String} password
+   */
+  FxAccountClient.prototype.accountLock = function (email, password) {
+    required(email, 'email');
+    required(password, 'password');
+
+    var self = this;
+    return credentials.setup(email, password)
+      .then(
+        function (result) {
+          var data = {
+            email: result.emailUTF8,
+            authPW: sjcl.codec.hex.fromBits(result.authPW)
+          };
+
+          return self.request.send('/account/lock', 'POST', null, data);
+        });
+  };
+
+
+  /**
+   * Send an account unlock code
+   *
+   * @method accountUnlockResendCode
+   * @param {String} email
+   * @param {Object} [options={}] Options
+   */
+  FxAccountClient.prototype.accountUnlockResendCode = function (email, options) {
+    required(email, 'email');
+
+    var data = {
+      email: email
+    };
+    if (options) {
+      if (options.service) {
+        data.service = options.service;
+      }
+
+      if (options.redirectTo) {
+        data.redirectTo = options.redirectTo;
+      }
+
+      if (options.resume) {
+        data.resume = options.resume;
+      }
+    }
+
+    return this.request.send('/account/unlock/resend_code', 'POST', null, data);
+  };
+
+  /**
+   * Verify an account unlock code
+   *
+   * @method accountUnlockVerifyCode
+   * @param {String} uid
+   * @param {String} code
+   */
+  FxAccountClient.prototype.accountUnlockVerifyCode = function (uid, code) {
+    required(uid, 'uid');
+    required(code, 'code');
+
+    return this.request.send('/account/unlock/verify_code', 'POST', null, {
+      uid: uid,
+      code: code
+    });
+  };
+
   return FxAccountClient;
 });
 

--- a/tests/lib/account.js
+++ b/tests/lib/account.js
@@ -323,6 +323,94 @@ define([
         });
       });
 
+      test('#accountLock', function () {
+        return accountHelper.newVerifiedAccount()
+          .then(
+            function (acc) {
+              account = acc;
+
+              return respond(client.accountLock(account.input.email, account.input.password), RequestMocks.accountLock);
+          })
+          .then(
+            function (result) {
+              // result is an empty object
+              assert.ok(result);
+              assert.equal(Object.keys(result).length, 0);
+            },
+            assert.notOk
+          );
+      });
+
+      test('#accountLock with no email', function () {
+        assert.throws(function () {
+          client.accountLock(null, account.input.password);
+        });
+      });
+
+      test('#accountLock with no password', function () {
+        assert.throws(function () {
+          client.accountLock(account.input.email, null);
+        });
+      });
+
+      test('#accountUnlockResendCode', function () {
+        var opts = {
+          service: 'sync',
+          redirectTo: 'https://sync.firefox.com/after_account_unlocked',
+          resume: 'resumejwt'
+        };
+
+        return accountHelper.newVerifiedAccount()
+          .then(
+            function (acc) {
+              account = acc;
+
+              return respond(client.accountLock(account.input.email, account.input.password), RequestMocks.accountLock);
+          })
+          .then(
+            function (result) {
+
+              return respond(client.accountUnlockResendCode(account.input.email, opts), RequestMocks.accountUnlockResendCode)
+          })
+          .then(
+            function (result) {
+              // result is an empty object
+              assert.ok(result);
+              assert.equal(Object.keys(result).length, 0);
+            },
+            assert.notOk
+          )
+      });
+
+      test('#accountUnlockResendCode with no email', function () {
+        assert.throws(function () {
+          client.accountUnlockResendCode();
+        });
+      });
+
+
+      test('#accountUnlockVerifyCode', function () {
+        return respond(client.accountUnlockVerifyCode('uid', 'code'), RequestMocks.accountUnlockVerifyCode)
+          .then(function (result) {
+            // result is an empty object
+            assert.ok(result);
+            assert.equal(Object.keys(result).length, 0);
+          },
+          assert.notOk
+        );
+      });
+
+      test('#accountUnlockVerifyCode with no uid', function () {
+        assert.throws(function () {
+          client.accountUnlockVerifyCode(null, 'code');
+        });
+      });
+
+      test('#accountUnlockVerifyCode with no code', function () {
+        assert.throws(function () {
+          client.accountUnlockVerifyCode('uid');
+        });
+      });
     });
   }
 });

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -144,6 +144,18 @@ define(['client/lib/errors'], function (ERRORS) {
     invalidTimestamp: {
       status: 401,
       body: '{ "errno": ' + ERRORS.INVALID_TIMESTAMP + ', "error": "Invalid authentication timestamp", "serverTime": ' + new Date().getTime() + ' }'
+    },
+    accountLock: {
+      status: 200,
+      body: '{}'
+    },
+    accountUnlockResendCode: {
+      status: 200,
+      body: '{}'
+    },
+    accountUnlockVerifyCode: {
+      status: 200,
+      body: '{}'
     }
   };
 });


### PR DESCRIPTION
* `accountUnlockResendCode` to send an unlock email
* `accountUnlockVerifyCode` to verify a code
* `accountLock` to lock an account, used only in testing.

fixes #134

Goes along with:
* https://github.com/mozilla/fxa-auth-db-server/pull/123
* https://github.com/mozilla/fxa-auth-db-mem/pull/11
* https://github.com/mozilla/fxa-auth-db-mysql/pull/7
* https://github.com/mozilla/fxa-auth-mailer/pull/23
* https://github.com/mozilla/fxa-content-server/pull/1806
* https://github.com/mozilla/fxa-auth-server/pull/867