### PR TITLE
cleanup(test): Disable IE8 tests.

### DIFF
--- a/tests/intern_sauce.js
+++ b/tests/intern_sauce.js
@@ -23,7 +23,7 @@ define([
 
   intern.environments = [
     { browserName: 'firefox', version: '25' , platform: [ 'Windows 7', 'Linux' ] },
-    { browserName: 'internet explorer', version: ['8', '9', '10'], platform: [ 'Windows 7' ] },
+    { browserName: 'internet explorer', version: ['9', '10'], platform: [ 'Windows 7' ] },
     { browserName: 'chrome' },
     { browserName: 'safari' }
   ];


### PR DESCRIPTION
@zaach or @vladikoff - could you give this a r?

We do not support IE8 and can safely disable the tests.

fixes #143 