### PR TITLE
feat(client): signIn can now pass along a `service` option.

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -139,6 +139,8 @@ define([
    *   If `true`, calls the API with `?keys=true` to get the keyFetchToken
    *   @param {Boolean} [options.skipCaseError]
    *   If `true`, the request will skip the incorrect case error
+   *   @param {String} [options.service]
+   *   Service being signed into
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.signIn = function (email, password, options) {
@@ -153,13 +155,17 @@ define([
         function (result) {
           var endpoint = '/account/login';
 
+          if (options.keys) {
+            endpoint += '?keys=true';
+          }
+
           var data = {
             email: result.emailUTF8,
             authPW: sjcl.codec.hex.fromBits(result.authPW)
           };
 
-          if (options.keys) {
-            endpoint += '?keys=true';
+          if (options.service) {
+            data.service = options.service;
           }
 
           return self.request.send(endpoint, 'POST', null, data)

--- a/tests/lib/signIn.js
+++ b/tests/lib/signIn.js
@@ -60,6 +60,16 @@ define([
           );
       });
 
+      test('#with service', function () {
+        var email = "test" + new Date().getTime() + "@restmail.net";
+        var password = "iliketurtles";
+
+        return respond(client.signUp(email, password), RequestMocks.signUp)
+          .then(function (res) {
+            return respond(client.signIn(email, password, {service: 'sync'}), RequestMocks.signIn);
+          });
+      });
+
       test('#incorrect email case', function () {
 
         return accountHelper.newVerifiedAccount()


### PR DESCRIPTION
@zaach  or @vladikoff - could you give an initial r? The backend and front end portions are not yet ready.

Used for account notifications. If `service===sync`, a notification email is sent to the user.

fixes #145

Link to:
https://github.com/mozilla/fxa-auth-mailer/pull/26
https://github.com/mozilla/fxa-auth-server/pull/876
https://github.com/mozilla/fxa-content-server/pull/2129