### PR TITLE
feat(client): Pass along `reason` in `signIn`

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -143,6 +143,9 @@ define([
    *   If `true`, the request will skip the incorrect case error
    *   @param {String} [options.service]
    *   Service being signed into
+   *   @param {String} [options.reason]
+   *   Reason for sign in. Can be one of: `signin`, `password_check`,
+   *   `password_change`, `password_reset`, `account_unlock`.
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.signIn = function (email, password, options) {
@@ -168,6 +171,10 @@ define([
 
           if (options.service) {
             data.service = options.service;
+          }
+
+          if (options.reason) {
+            data.reason = options.reason;
           }
 
           return self.request.send(endpoint, 'POST', null, data)

--- a/tests/lib/signIn.js
+++ b/tests/lib/signIn.js
@@ -65,8 +65,18 @@ define([
         var password = "iliketurtles";
 
         return respond(client.signUp(email, password), RequestMocks.signUp)
-          .then(function (res) {
+          .then(function () {
             return respond(client.signIn(email, password, {service: 'sync'}), RequestMocks.signIn);
+          });
+      });
+
+      test('#with reason', function () {
+        var email = "test" + new Date().getTime() + "@restmail.net";
+        var password = "iliketurtles";
+
+        return respond(client.signUp(email, password), RequestMocks.signUp)
+          .then(function () {
+            return respond(client.signIn(email, password, {reason: 'password_change'}), RequestMocks.signIn);
           });
       });
 


### PR DESCRIPTION
@vladikoff or @zaach - r?

`reason` will be used along with `service` on the auth server to decide when to send notification emails.

fixes #150 