### PR TITLE
fix(request): Return rejected promise immediately if xhr.open() fails

### DIFF
--- a/client/lib/request.js
+++ b/client/lib/request.js
@@ -53,7 +53,7 @@ define(['./hawk', 'p', './errors'], function (hawk, P, ERRORS) {
     try {
       xhr.open(method, uri);
     } catch (e) {
-      deferred.reject({ error: 'Unknown error', message: e.toString(), errno: 999 });
+      return P.reject({ error: 'Unknown error', message: e.toString(), errno: 999 });
     }
 
     xhr.timeout = this.timeout;

--- a/tests/lib/request.js
+++ b/tests/lib/request.js
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
+  'tests/addons/sinon',
   'intern!tdd',
   'intern/chai!assert',
   'tests/addons/environment',
   'client/lib/request',
   'tests/mocks/errors'
-], function (tdd, assert, Environment, Request, ErrorMocks) {
+], function (sinon, tdd, assert, Environment, Request, ErrorMocks) {
   with (tdd) {
     suite('request module', function () {
       var RequestMocks;
@@ -71,6 +72,20 @@ define([
             assert.equal(err.error, 'Unknown error');
           }
         );
+      });
+
+      test('#ensure is usable', function () {
+        request = new Request('http://google.com:81', env.xhr, { timeout: 200 });
+        sinon.stub(env.xhr.prototype, 'open').throws();
+
+        return env.respond(request.send('/__heartbeat__', 'GET'), RequestMocks.heartbeat)
+          .then(
+            null,
+            function (err) {
+              assert.ok(err);
+              env.xhr.prototype.open.restore();
+            }
+          );
       });
     });
   }


### PR DESCRIPTION
Fixes #174