### PR TITLE
feat(client): Add "devices API" options to signIn and signUp

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -75,6 +75,11 @@ define([
    *   example.
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
+   *   @param {Object} [options.device={}] Device registration information
+   *     @param {String} name Name of device
+   *     @param {String} type Type of device (mobile|desktop)
+   *     @param {string} [callback] Device's push endpoint.
+   *     @param {string} [publicKey] Public key used to encrypt push messages.
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.signUp = function (email, password, options) {
@@ -95,6 +100,21 @@ define([
           var requestOpts = {};
 
           if (options) {
+            if (options.device) {
+              data.device = {
+                name: options.device.name,
+                type: options.device.type
+              };
+
+              if (options.device.callback) {
+                data.device.pushCallback = options.device.callback;
+              }
+
+              if (options.device.publicKey) {
+                data.device.pushPublicKey = options.device.publicKey;
+              }
+            }
+
             if (options.service) {
               data.service = options.service;
             }
@@ -158,6 +178,12 @@ define([
    *   @param {String} [options.reason]
    *   Reason for sign in. Can be one of: `signin`, `password_check`,
    *   `password_change`, `password_reset`, `account_unlock`.
+   *   @param {Object} [options.device={}] Device registration information
+   *     @param {String} [id] User-unique identifier of device
+   *     @param {String} [name] Name of device
+   *     @param {String} [type] Type of device (mobile|desktop)
+   *     @param {string} [callback] Device's push endpoint.
+   *     @param {string} [publicKey] Public key used to encrypt push messages.
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.signIn = function (email, password, options) {
@@ -180,6 +206,30 @@ define([
             email: result.emailUTF8,
             authPW: sjcl.codec.hex.fromBits(result.authPW)
           };
+
+          if (options.device) {
+            data.device = {};
+
+            if (options.device.id) {
+              data.device.id = options.device.id;
+            }
+
+            if (options.device.name) {
+              data.device.name = options.device.name;
+            }
+
+            if (options.device.type) {
+              data.device.type = options.device.type;
+            }
+
+            if (options.device.callback) {
+              data.device.pushCallback = options.device.callback;
+            }
+
+            if (options.device.publicKey) {
+              data.device.pushPublicKey = options.device.publicKey;
+            }
+          }
 
           if (options.service) {
             data.service = options.service;

--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -13,6 +13,7 @@ define([
 
   var VERSION = 'v1';
   var uriVersionRegExp = new RegExp('/' + VERSION + '$');
+  var HKDF_SIZE = 2 * 32;
 
   function required(val, name) {
     if (!val) {
@@ -85,7 +86,7 @@ define([
     return credentials.setup(email, password)
       .then(
         function (result) {
-          /*eslint complexity: [2, 9] */
+          /*eslint complexity: [2, 12] */
           var endpoint = '/account/create';
           var data = {
             email: result.emailUTF8,
@@ -235,7 +236,7 @@ define([
     var self = this;
     required(sessionToken, 'sessionToken');
 
-    return hawkCredentials(sessionToken, 'sessionToken',  2 * 32)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         return self.request.send('/recovery_email/status', 'GET', creds);
       });
@@ -286,7 +287,7 @@ define([
       }
     }
 
-    return hawkCredentials(sessionToken, 'sessionToken',  2 * 32)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         return self.request.send('/recovery_email/resend_code', 'POST', creds, data, requestOpts);
       });
@@ -392,7 +393,7 @@ define([
       }
     }
 
-    return hawkCredentials(passwordForgotToken, 'passwordForgotToken',  2 * 32)
+    return hawkCredentials(passwordForgotToken, 'passwordForgotToken',  HKDF_SIZE)
       .then(function(creds) {
         return self.request.send('/password/forgot/resend_code', 'POST', creds, data, requestOpts);
       });
@@ -413,7 +414,7 @@ define([
     required(code, 'reset code');
     required(passwordForgotToken, 'passwordForgotToken');
 
-    return hawkCredentials(passwordForgotToken, 'passwordForgotToken',  2 * 32)
+    return hawkCredentials(passwordForgotToken, 'passwordForgotToken',  HKDF_SIZE)
       .then(function(creds) {
         return self.request.send('/password/forgot/verify_code', 'POST', creds, {
           code: code
@@ -434,7 +435,7 @@ define([
 
     required(passwordForgotToken, 'passwordForgotToken');
 
-    return hawkCredentials(passwordForgotToken, 'passwordForgotToken',  2 * 32)
+    return hawkCredentials(passwordForgotToken, 'passwordForgotToken',  HKDF_SIZE)
       .then(function(creds) {
         return self.request.send('/password/forgot/status', 'GET', creds);
       });
@@ -463,7 +464,7 @@ define([
         function (result) {
           authPW = sjcl.codec.hex.fromBits(result.authPW);
 
-          return hawkCredentials(accountResetToken, 'accountResetToken',  2 * 32);
+          return hawkCredentials(accountResetToken, 'accountResetToken',  HKDF_SIZE);
         }
       ).then(
         function (creds) {
@@ -583,7 +584,7 @@ define([
 
     required(sessionToken, 'sessionToken');
 
-    return hawkCredentials(sessionToken, 'sessionToken',  2 * 32)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         return self.request.send('/session/destroy', 'POST', creds);
       });
@@ -601,7 +602,7 @@ define([
 
     required(sessionToken, 'sessionToken');
 
-    return hawkCredentials(sessionToken, 'sessionToken',  2 * 32)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         return self.request.send('/session/status', 'GET', creds);
       });
@@ -627,7 +628,7 @@ define([
     required(publicKey, 'publicKey');
     required(duration, 'duration');
 
-    return hawkCredentials(sessionToken, 'sessionToken',  2 * 32)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         return self.request.send('/certificate/sign', 'POST', creds, data);
       });
@@ -750,7 +751,7 @@ define([
     required(keys.kB, 'keys.kB');
 
     var p1 = credentials.setup(email, newPassword);
-    var p2 = hawkCredentials(oldCreds.passwordChangeToken, 'passwordChangeToken',  2 * 32);
+    var p2 = hawkCredentials(oldCreds.passwordChangeToken, 'passwordChangeToken',  HKDF_SIZE);
 
     return P.all([p1, p2])
       .spread(function(newCreds, hawkCreds) {
@@ -850,6 +851,119 @@ define([
       code: code
     });
   };
+
+  /**
+   * Add a new device
+   *
+   * @method deviceRegister
+   * @param {String} sessionToken User session token
+   * @param {String} deviceName Name of device
+   * @param {String} deviceType Type of device (mobile|desktop)
+   * @param {Object} [options={}] Options
+   *   @param {string} [options.deviceCallback] Device's push endpoint.
+   *   @param {string} [options.devicePublicKey] Public key used to encrypt push messages.
+   * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+   */
+  FxAccountClient.prototype.deviceRegister = function (sessionToken, deviceName, deviceType, options) {
+    options = options || {};
+
+    required(sessionToken, 'sessionToken');
+    required(deviceName, 'deviceName');
+    required(deviceType, 'deviceType');
+
+    var request = this.request;
+    return hawkCredentials(sessionToken, 'deviceRegister',  HKDF_SIZE)
+      .then(function(creds) {
+        var data = {
+          name: deviceName,
+          type: deviceType
+        };
+
+        if (options.deviceCallback && options.devicePublicKey) {
+          data.pushCallback = options.deviceCallback;
+          data.pushPublicKey = options.devicePublicKey;
+        }
+
+        return request.send('/account/device', 'POST', creds, data);
+      });
+  };
+
+  /**
+   * Update the name of an existing device
+   *
+   * @method deviceRegister
+   * @param {String} sessionToken User session token
+   * @param {String} deviceId User-unique identifier of device
+   * @param {String} deviceName Name of device
+   * @param {Object} [options={}] Options
+   *   @param {string} [options.deviceCallback] Device's push endpoint.
+   *   @param {string} [options.devicePublicKey] Public key used to encrypt push messages.
+   * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+   */
+  FxAccountClient.prototype.deviceUpdate = function (sessionToken, deviceId, deviceName, options) {
+    options = options || {};
+
+    required(sessionToken, 'sessionToken');
+    required(deviceId, 'deviceId');
+    required(deviceName, 'deviceName');
+
+    var request = this.request;
+    return hawkCredentials(sessionToken, 'deviceUpdate',  HKDF_SIZE)
+      .then(function(creds) {
+        var data = {
+          id: deviceId,
+          name: deviceName
+        };
+
+        if (options.deviceCallback && options.devicePublicKey) {
+          data.pushCallback = options.deviceCallback;
+          data.pushPublicKey = options.devicePublicKey;
+        }
+
+        return request.send('/account/device', 'POST', creds, data);
+      });
+  };
+
+  /**
+   * Unregister an existing device
+   *
+   * @method deviceDestroy
+   * @param {String} sessionToken Session token obtained from signIn
+   * @param {String} deviceId User-unique identifier of device
+   * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+   */
+  FxAccountClient.prototype.deviceDestroy = function (sessionToken, deviceId) {
+    required(sessionToken, 'sessionToken');
+    required(deviceId, 'deviceId');
+
+    var request = this.request;
+    return hawkCredentials(sessionToken, 'deviceDestroy',  HKDF_SIZE)
+      .then(function(creds) {
+        var data = {
+          id: deviceId
+        };
+
+        return request.send('/account/device/destroy', 'POST', creds, data);
+      });
+  };
+
+  /**
+   * Get a list of all devices for a user
+   *
+   * @method deviceList
+   * @param {String} sessionToken sessionToken obtained from signIn
+   * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+   */
+  FxAccountClient.prototype.deviceList = function (sessionToken) {
+    required(sessionToken, 'sessionToken');
+
+    var request = this.request;
+    return hawkCredentials(sessionToken, 'devices',  HKDF_SIZE)
+      .then(function(creds) {
+        return request.send('/account/devices', 'GET', creds);
+      });
+  };
+
 
   return FxAccountClient;
 });

--- a/tests/all.js
+++ b/tests/all.js
@@ -20,5 +20,6 @@ define([
   'tests/lib/misc',
   'tests/lib/errors',
   'tests/lib/headerLang',
-  'tests/lib/uriVersion'
+  'tests/lib/uriVersion',
+  'tests/lib/device'
 ], function () {});

--- a/tests/lib/push-constants.js
+++ b/tests/lib/push-constants.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([], function () {
+  return {
+    DEVICE_CALLBACK: 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
+    DEVICE_ID: '0f7aa00356e5416e82b3bef7bc409eef',
+    DEVICE_NAME: 'My Phone',
+    DEVICE_NAME_2: 'My Android Phone',
+    DEVICE_PUBLIC_KEY: '468601214f60f4828b6cd5d51d9d99d212e7c73657978955f0f5a5b7e2fa1370',
+    DEVICE_TYPE: 'mobile'
+  };
+});
+

--- a/tests/lib/signUp.js
+++ b/tests/lib/signUp.js
@@ -5,8 +5,15 @@
 define([
   'intern!tdd',
   'intern/chai!assert',
-  'tests/addons/environment'
-], function (tdd, assert, Environment) {
+  'tests/addons/environment',
+  'tests/lib/push-constants'
+], function (tdd, assert, Environment, PushTestConstants) {
+
+  var DEVICE_CALLBACK = PushTestConstants.DEVICE_CALLBACK;
+  var DEVICE_ID = PushTestConstants.DEVICE_ID;
+  var DEVICE_NAME = PushTestConstants.DEVICE_NAME;
+  var DEVICE_PUBLIC_KEY = PushTestConstants.DEVICE_PUBLIC_KEY;
+  var DEVICE_TYPE = PushTestConstants.DEVICE_TYPE;
 
   with (tdd) {
     suite('signUp', function () {
@@ -228,6 +235,47 @@ define([
         );
       });
 
+      test('#with new device', function () {
+        var email = 'test' + new Date().getTime() + '@restmail.net';
+        var password = 'iliketurtles';
+
+        return respond(client.signUp(email, password, {
+          device: {
+            name: DEVICE_NAME,
+            type: DEVICE_TYPE,
+            callback: DEVICE_CALLBACK,
+            publicKey: DEVICE_PUBLIC_KEY
+          }
+        }), RequestMocks.signUpNewDevice)
+        .then(function (resp) {
+          var device = resp.device;
+          assert.equal(device.id, DEVICE_ID);
+          assert.equal(device.name, DEVICE_NAME);
+          assert.equal(device.type, DEVICE_TYPE);
+          assert.equal(device.pushCallback, DEVICE_CALLBACK);
+          assert.equal(device.pushPublicKey, DEVICE_PUBLIC_KEY);
+        });
+      });
+
+      test('#with existing device', function () {
+        var email = 'test' + new Date().getTime() + '@restmail.net';
+        var password = 'iliketurtles';
+
+        return respond(client.signUp(email, password, {
+          device: {
+            id: DEVICE_ID,
+            name: DEVICE_NAME
+          }
+        }), RequestMocks.signUpExistingDevice)
+        .then(function (resp) {
+          var device = resp.device;
+          assert.equal(device.id, DEVICE_ID);
+          assert.equal(device.name, DEVICE_NAME);
+          assert.equal(device.type, DEVICE_TYPE);
+          assert.equal(device.pushCallback, DEVICE_CALLBACK);
+          assert.equal(device.pushPublicKey, DEVICE_PUBLIC_KEY);
+        });
+      });
     });
   }
 });

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -3,7 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //jscs:disable maximumLineLength
-define(['client/lib/errors'], function (ERRORS) {
+define([
+  'client/lib/errors',
+  'tests/lib/push-constants'
+], function (ERRORS, PushTestConstants) {
+
+  var DEVICE_CALLBACK = PushTestConstants.DEVICE_CALLBACK;
+  var DEVICE_ID = PushTestConstants.DEVICE_ID;
+  var DEVICE_NAME = PushTestConstants.DEVICE_NAME;
+  var DEVICE_NAME_2 = PushTestConstants.DEVICE_NAME_2;
+  var DEVICE_PUBLIC_KEY = PushTestConstants.DEVICE_PUBLIC_KEY;
+  var DEVICE_TYPE = PushTestConstants.DEVICE_TYPE;
+
   return {
     signUp: {
       status: 200,
@@ -157,6 +168,46 @@ define(['client/lib/errors'], function (ERRORS) {
     accountUnlockVerifyCode: {
       status: 200,
       body: '{}'
+    },
+    deviceDestroy: {
+      status: 200,
+      body: '{}'
+    },
+    deviceList: {
+      status: 200,
+      body: JSON.stringify([
+        {
+          id: DEVICE_ID,
+          name: DEVICE_NAME,
+          type: DEVICE_TYPE,
+          pushCallback: DEVICE_CALLBACK,
+          pushPublicKey: DEVICE_PUBLIC_KEY
+        }
+      ])
+    },
+    deviceRegister: {
+      status: 200,
+      body: JSON.stringify(
+        {
+          id: DEVICE_ID,
+          name: DEVICE_NAME,
+          type: DEVICE_TYPE,
+          pushCallback: DEVICE_CALLBACK,
+          pushPublicKey: DEVICE_PUBLIC_KEY
+        }
+      )
+    },
+    deviceUpdate: {
+      status: 200,
+      body: JSON.stringify(
+        {
+          id: DEVICE_ID,
+          name: DEVICE_NAME_2,
+          type: DEVICE_TYPE,
+          pushCallback: DEVICE_CALLBACK,
+          pushPublicKey: DEVICE_PUBLIC_KEY
+        }
+      )
     }
   };
 });

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -21,20 +21,84 @@ define([
       headers: {},
       body: '{ "uid": "0577e7a5fbf448e3bc60dacbff5dcd5c", "sessionToken": "27cd4f4a4aa03d7d186a2ec81cbf19d5c8a604713362df9ee15c4f4a4aa03d7d"}'
     },
+    signUpExistingDevice: {
+      status: 200,
+      headers: {},
+      body: JSON.stringify({
+        device:{
+          id: DEVICE_ID,
+          name: DEVICE_NAME,
+          type: DEVICE_TYPE,
+          pushCallback: DEVICE_CALLBACK,
+          pushPublicKey: DEVICE_PUBLIC_KEY
+        },
+        sessionToken:'6544062365c5ebee16e3c5e15448139851583b5f5f7b6bd6d4a37bac41665e8a',
+        uid:'9c8e5cf6915949c1b063b88fa0c53d05',
+        verified:true,
+      })
+    },
     signUpKeys: {
       status: 200,
       headers: {},
       body: '{ "uid": "0577e7a5fbf448e3bc60dacbff5dcd5c", "sessionToken": "27cd4f4a4aa03d7d186a2ec81cbf19d5c8a604713362df9ee15c4f4a4aa03d7d","keyFetchToken": "b1f4182d7e072567a1dbe682043a16932a84b7f4ca3b95e471a34806c87e4130"  }'
+    },
+    signUpNewDevice: {
+      status: 200,
+      headers: {},
+      body: JSON.stringify({
+        device:{
+          id: DEVICE_ID,
+          name: DEVICE_NAME,
+          type: DEVICE_TYPE,
+          pushCallback: DEVICE_CALLBACK,
+          pushPublicKey: DEVICE_PUBLIC_KEY
+        },
+        sessionToken:'6544062365c5ebee16e3c5e15448139851583b5f5f7b6bd6d4a37bac41665e8a',
+        uid:'9c8e5cf6915949c1b063b88fa0c53d05',
+        verified:true,
+      })
     },
     signIn: {
       status: 200,
       headers: {},
       body: '{"uid":"9c8e5cf6915949c1b063b88fa0c53d05","verified":true,"sessionToken":"6544062365c5ebee16e3c5e15448139851583b5f5f7b6bd6d4a37bac41665e8a"}'
     },
+    signInExistingDevice: {
+      status: 200,
+      headers: {},
+      body: JSON.stringify({
+        device:{
+          id: DEVICE_ID,
+          name: DEVICE_NAME,
+          type: DEVICE_TYPE,
+          pushCallback: DEVICE_CALLBACK,
+          pushPublicKey: DEVICE_PUBLIC_KEY
+        },
+        sessionToken:'6544062365c5ebee16e3c5e15448139851583b5f5f7b6bd6d4a37bac41665e8a',
+        uid:'9c8e5cf6915949c1b063b88fa0c53d05',
+        verified:true,
+      })
+    },
     signInFailurePassword: {
       status: 400,
       headers: {},
       body: '{"code":400,"message":"Incorrect password"}'
+    },
+    signInNewDevice: {
+      status: 200,
+      headers: {},
+      body: JSON.stringify({
+        device:{
+          id: DEVICE_ID,
+          name: DEVICE_NAME,
+          type: DEVICE_TYPE,
+          pushCallback: DEVICE_CALLBACK,
+          pushPublicKey: DEVICE_PUBLIC_KEY
+        },
+        sessionToken:'6544062365c5ebee16e3c5e15448139851583b5f5f7b6bd6d4a37bac41665e8a',
+        uid:'9c8e5cf6915949c1b063b88fa0c53d05',
+        verified:true,
+      })
     },
     signInWithKeys: {
       status: 200,


### PR DESCRIPTION
This is a follow on to #177 to add `devices` options to `signIn` and `signUp`. To be merged once the auth-server portion of this functionality is ready.