### PR TITLE
fix(client): Send `sessionToken` as the `context` when creating Hawk creds.

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -872,7 +872,7 @@ define([
     required(deviceType, 'deviceType');
 
     var request = this.request;
-    return hawkCredentials(sessionToken, 'deviceRegister',  HKDF_SIZE)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         var data = {
           name: deviceName,
@@ -908,7 +908,7 @@ define([
     required(deviceName, 'deviceName');
 
     var request = this.request;
-    return hawkCredentials(sessionToken, 'deviceUpdate',  HKDF_SIZE)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         var data = {
           id: deviceId,
@@ -937,7 +937,7 @@ define([
     required(deviceId, 'deviceId');
 
     var request = this.request;
-    return hawkCredentials(sessionToken, 'deviceDestroy',  HKDF_SIZE)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         var data = {
           id: deviceId
@@ -958,7 +958,7 @@ define([
     required(sessionToken, 'sessionToken');
 
     var request = this.request;
-    return hawkCredentials(sessionToken, 'devices',  HKDF_SIZE)
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
         return request.send('/account/devices', 'GET', creds);
       });


### PR DESCRIPTION
I thought `context` when calling `hawkCredentials` was a human readable description instead of one of `sessionToken`, `passwordForgotToken`, or `accountResetToken`.