### PR TITLE
feat(client): Add new client function to get account status from options

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -16,7 +16,7 @@ define([
   var HKDF_SIZE = 2 * 32;
 
   function required(val, name) {
-    if (!val) {
+    if (!val || val === {}) {
       throw new Error('Missing ' + name);
     }
   }
@@ -610,7 +610,7 @@ define([
   };
 
   /**
-   * Gets the status of an account
+   * Gets the status of an account by uid.
    *
    * @method accountStatus
    * @param {String} uid User account id
@@ -620,6 +620,19 @@ define([
     required(uid, 'uid');
 
     return this.request.send('/account/status?uid=' + uid, 'GET');
+  };
+
+  /**
+   * Gets the status of an account by email.
+   *
+   * @method accountStatusByEmail
+   * @param {String} email User account email
+   * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+   */
+  FxAccountClient.prototype.accountStatusByEmail = function(email) {
+    required(email, 'email');
+
+    return this.request.send('/account/status', 'POST', null, {email: email});
   };
 
   /**

--- a/tests/lib/account.js
+++ b/tests/lib/account.js
@@ -320,7 +320,40 @@ define([
 
         assert.throws(function() {
           client.accountStatus();
-        });
+        }, 'Missing uid');
+      });
+
+      test('#accountStatusByEmail', function () {
+
+        return accountHelper.newVerifiedAccount()
+          .then(function (result) {
+
+            return respond(client.accountStatusByEmail(result.input.email), RequestMocks.accountStatus);
+          })
+          .then(
+            function (res) {
+              assert.equal(res.exists, true);
+            },
+            assert.notOk
+          );
+      });
+
+      test('#accountStatusByEmail with wrong email', function () {
+
+        return respond(client.accountStatusByEmail('invalid@email.com'), RequestMocks.accountStatusFalse)
+          .then(
+            function (res) {
+              assert.equal(res.exists, false);
+            },
+            assert.notOk
+          );
+      });
+
+      test('#accountStatusByEmail with no email', function () {
+
+        assert.throws(function() {
+          client.accountStatusByEmail();
+        }, 'Missing email');
       });
 
       test('#accountLock', function () {


### PR DESCRIPTION
This PR adds the ability to query account status by email to the client script. It uses the auth endpoint [/v1/account/status](https://github.com/mozilla/fxa-auth-server/blob/master/docs/api.md#post-v1accountstatus).

This supports https://github.com/mozilla/fxa-content-server/pull/3537