### PR TITLE
feat(client): add optional metricsContext metadata

### DIFF
--- a/client/lib/metricsContext.js
+++ b/client/lib/metricsContext.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This module does the handling for the metrics context
+// activity event metadata.
+
+define([], function () {
+  'use strict';
+
+  var OPTIONS = {
+    context: true,
+    entrypoint: true,
+    migration: true,
+    service: true,
+    utmCampaign: true,
+    utmContent: true,
+    utmMedium: true,
+    utmSource: true,
+    utmTerm: true
+  };
+
+  return {
+    marshall: function (data) {
+      var metricsContext = {
+        flowId: data.flowId,
+        flowBeginTime: data.flowBeginTime
+      };
+
+      for (var key in data) {
+        if (data.hasOwnProperty(key) && data[key] && OPTIONS[key]) {
+          metricsContext[key] = data[key];
+        }
+      }
+
+      return metricsContext;
+    }
+  };
+});

--- a/tests/lib/certificateSign.js
+++ b/tests/lib/certificateSign.js
@@ -44,6 +44,34 @@ define([
           );
       });
 
+      test('#with metricsContext metadata', function () {
+        return accountHelper.newVerifiedAccount()
+          .then(function (account) {
+            var publicKey = {
+              algorithm: 'RS',
+              n: '4759385967235610503571494339196749614544606692567785790953934768202714280652973091341316862993582789079872007974809511698859885077002492642203267408776123',
+              e: '65537'
+            };
+            var duration = 86400000;
+
+            return respond(
+              client.certificateSign(account.signIn.sessionToken, publicKey, duration, {
+                metricsContext: {
+                  flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+                  flowBeginTime: Date.now(),
+                  forbiddenProperty: 666
+                }
+              }),
+              RequestMocks.certificateSign
+            );
+          })
+          .then(
+            function(res) {
+              assert.ok(res);
+            },
+            assert.notOk
+          );
+      });
     });
   }
 });

--- a/tests/lib/signIn.js
+++ b/tests/lib/signIn.js
@@ -184,6 +184,28 @@ define([
             assert.isUndefined(resp.device);
           });
       });
+
+      test('#with metricsContext metadata', function () {
+        var email = 'test' + new Date().getTime() + '@restmail.net';
+        var password = 'iliketurtles';
+
+        return respond(client.signUp(email, password), RequestMocks.signUp)
+          .then(function () {
+            return respond(
+              client.signIn(email, password, {
+                metricsContext: {},
+                reason: 'signin'
+              }),
+              RequestMocks.signIn
+            );
+          })
+          .then(
+            function (resp) {
+              assert.ok(resp);
+            },
+            assert.notOk
+          );
+      });
     });
   }
 });

--- a/tests/lib/signUp.js
+++ b/tests/lib/signUp.js
@@ -256,6 +256,27 @@ define([
         });
       });
 
+      test('#with metricsContext metadata', function () {
+        var email = 'test' + new Date().getTime() + '@restmail.net';
+        var password = 'iliketurtles';
+
+        return respond(
+          client.signUp(email, password, {
+            metricsContext: {
+              flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+              flowBeginTime: Date.now(),
+              forbiddenProperty: 666
+            }
+          }),
+          RequestMocks.signUp
+        )
+        .then(
+          function (resp) {
+            assert.ok(resp);
+          },
+          assert.notOk
+        );
+      });
     });
   }
 });


### PR DESCRIPTION
This change is to enable https://github.com/mozilla/fxa-content-server/issues/3551, propagation of metrics context metadata to the auth server for [FxA-70](https://github.com/mozilla/fxa/tree/master/features/FxA-70-kpi-dashboards).

~~Something I wasn't sure about: I call `Object.keys` and `Array.forEach` at one point, are they safe to use in this repo or does it need to be ES3-safe? Happy to replace them with an old-fashioned loop if necessary.~~

**EDIT:** This PR is dependent on https://github.com/mozilla/fxa-auth-server/pull/1213, it can't be merged until that one is.