### PR TITLE
feat(client): verifyCode support for `service` parameter

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -248,16 +248,27 @@ define([
    * @method verifyCode
    * @param {String} uid Account ID
    * @param {String} code Verification code
+   * @param {Object} [options={}] Options
+   *   @param {String} [options.service]
+   *   Service being signed into
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
-  FxAccountClient.prototype.verifyCode = function(uid, code) {
+  FxAccountClient.prototype.verifyCode = function(uid, code, options) {
     required(uid, 'uid');
     required(code, 'verify code');
 
-    return this.request.send('/recovery_email/verify_code', 'POST', null, {
+    var data = {
       uid: uid,
       code: code
-    });
+    };
+
+    if (options) {
+      if (options.service) {
+        data.service = options.service;
+      }
+    }
+
+    return this.request.send('/recovery_email/verify_code', 'POST', null, data);
   };
 
   /**

--- a/tests/lib/verifyCode.js
+++ b/tests/lib/verifyCode.js
@@ -95,6 +95,34 @@ define([
             assert.notOk
           );
       });
+
+      test('#verifyEmail with service param', function () {
+        var user = 'test5' + new Date().getTime();
+        var email = user + '@restmail.net';
+        var password = 'iliketurtles';
+        var uid;
+
+        return respond(client.signUp(email, password), RequestMocks.signUp)
+          .then(function (result) {
+            uid = result.uid;
+            assert.ok(uid, 'uid is returned');
+
+            return respond(mail.wait(user), RequestMocks.mail);
+          })
+          .then(function (emails) {
+            var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
+            assert.ok(code, 'code is returned');
+
+            return respond(client.verifyCode(uid, code, { service: 'sync' }),
+                    RequestMocks.verifyCode);
+          })
+          .then(
+            function (result) {
+              assert.ok(result);
+            },
+            assert.notOk
+          );
+      });
     });
   }
 });


### PR DESCRIPTION
Allows passing a `service` parameter when verifying the email code; Connects to https://github.com/mozilla/fxa-auth-server/issues/1249

I added a "doesn't blow up when called with service parameter" test, but couldn't see a good way of testing the details of this - at least, not without adding code to intercept the HTTP request and check that `service` was included in the parameters.  Is that something I should try to do?