### PR TITLE
feat(client): signIn support signin confirmation

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -175,6 +175,12 @@ define([
    *   @param {String} [options.reason]
    *   Reason for sign in. Can be one of: `signin`, `password_check`,
    *   `password_change`, `password_reset`, `account_unlock`.
+   *   @param {String} [options.redirectTo]
+   *   a URL that the client should be redirected to after handling the request
+   *   @param {String} [options.resume]
+   *   Opaque url-encoded string that will be included in the verification link
+   *   as a querystring parameter, useful for continuing an OAuth flow for
+   *   example.
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
@@ -210,16 +216,24 @@ define([
             authPW: sjcl.codec.hex.fromBits(result.authPW)
           };
 
-          if (options.service) {
-            data.service = options.service;
+          if (options.metricsContext) {
+            data.metricsContext = metricsContext.marshall(options.metricsContext);
           }
 
           if (options.reason) {
             data.reason = options.reason;
           }
 
-          if (options.metricsContext) {
-            data.metricsContext = metricsContext.marshall(options.metricsContext);
+          if (options.redirectTo) {
+            data.redirectTo = options.redirectTo;
+          }
+
+          if (options.resume) {
+            data.resume = options.resume;
+          }
+
+          if (options.service) {
+            data.service = options.service;
           }
 
           return self.request.send(endpoint, 'POST', null, data)

--- a/tests/ci/travis-auth-server-test.sh
+++ b/tests/ci/travis-auth-server-test.sh
@@ -3,7 +3,7 @@
 # Install and start the auth server
 git clone https://github.com/mozilla/fxa-auth-server.git
 cd fxa-auth-server && npm i
-npm start &
+SIGNIN_CONFIRMATION_ENABLED=true npm start &
 cd ..
 sleep 5
 

--- a/tests/lib/signIn.js
+++ b/tests/lib/signIn.js
@@ -11,19 +11,21 @@ define([
 
   with (tdd) {
     suite('signIn', function () {
-      var accountHelper;
-      var respond;
-      var client;
-      var RequestMocks;
       var ErrorMocks;
+      var RequestMocks;
+      var accountHelper;
+      var client;
+      var mail;
+      var respond;
 
       beforeEach(function () {
         var env = new Environment();
-        accountHelper = env.accountHelper;
-        respond = env.respond;
-        client = env.client;
-        RequestMocks = env.RequestMocks;
         ErrorMocks = env.ErrorMocks;
+        RequestMocks = env.RequestMocks;
+        accountHelper = env.accountHelper;
+        client = env.client;
+        mail = env.mail;
+        respond = env.respond;
       });
 
       test('#basic', function () {
@@ -80,6 +82,77 @@ define([
             return respond(client.signIn(email, password, {reason: 'password_change'}), RequestMocks.signIn);
           });
       });
+
+      test('#with Sync/redirectTo', function () {
+        var user = 'test' + new Date().getTime();
+        var email = user + '@restmail.net';
+        var password = 'iliketurtles';
+        var opts = {
+          keys: true,
+          metricsContext: {
+            context: 'fx_desktop_v2'
+          },
+          redirectTo: 'http://sync.firefox.com/after_reset',
+          service: 'sync'
+        };
+
+        return respond(client.signUp(email, password, { preVerified: true }), RequestMocks.signUp)
+          .then(function () {
+
+            return respond(client.signIn(email, password, opts), RequestMocks.signIn);
+          })
+          .then(function (res) {
+            assert.ok(res.uid);
+            return respond(mail.wait(user), RequestMocks.mailServiceAndRedirect);
+          })
+          .then(
+            function (emails) {
+              var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
+              var redirectTo = emails[0].html.match(/redirectTo=([A-Za-z0-9]+)/)[1];
+
+              assert.ok(code, 'code is returned');
+              assert.ok(redirectTo, 'redirectTo is returned');
+
+            },
+            assert.notOk
+          );
+      });
+
+      test('#with Sync/resume', function () {
+        var user = 'test' + new Date().getTime();
+        var email = user + '@restmail.net';
+        var password = 'iliketurtles';
+        var opts = {
+          keys: true,
+          metricsContext: {
+            context: 'fx_desktop_v2'
+          },
+          redirectTo: 'http://sync.firefox.com/after_reset',
+          resume: 'resumejwt',
+          service: 'sync'
+        };
+
+        return respond(client.signUp(email, password, { preVerified: true }), RequestMocks.signUp)
+          .then(function () {
+            return respond(client.signIn(email, password, opts), RequestMocks.signIn);
+          })
+          .then(function (res) {
+            assert.ok(res.uid);
+            return respond(mail.wait(user), RequestMocks.mailServiceAndRedirect);
+          })
+          .then(
+            function (emails) {
+              var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
+              var resume = emails[0].html.match(/resume=([A-Za-z0-9]+)/)[1];
+
+              assert.ok(code, 'code is returned');
+              assert.ok(resume, 'resume is returned');
+
+            },
+            assert.notOk
+          );
+      });
+
 
       test('#incorrect email case', function () {
 


### PR DESCRIPTION
* signIn now accepts `redirectTo` and `resume` options.

Goes with https://github.com/mozilla/fxa-auth-server/pull/1275, https://github.com/mozilla/fxa-content-server/pull/3671