### PR TITLE
Eliminate redundant payload data

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -743,6 +743,7 @@ define([
    * @param {Object} publicKey The key to sign
    * @param {int} duration Time interval from now when the certificate will expire in milliseconds
    * @param {Object} [options={}] Options
+   *   @param {String} [service=''] The requesting service, sent via the query string
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
@@ -770,13 +771,18 @@ define([
 
     options = options || {};
 
+    var queryString = '';
+    if (options.service) {
+      queryString = '?service=' + encodeURIComponent(options.service);
+    }
+
     if (options.metricsContext) {
       data.metricsContext = metricsContext.marshall(options.metricsContext);
     }
 
     return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
-        return self.request.send('/certificate/sign', 'POST', creds, data);
+        return self.request.send('/certificate/sign' + queryString, 'POST', creds, data);
       });
   };
 

--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -519,18 +519,6 @@ define([
    *   is required if `options.keys` is true.
    *   @param {Boolean} [options.sessionToken]
    *   If `true`, a new `sessionToken` is provisioned.
-   *   @param {Object} [options.metricsContext={}] Metrics context metadata
-   *     @param {String} options.metricsContext.flowId identifier for the current event flow
-   *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
-   *     @param {String} [options.metricsContext.context] context identifier
-   *     @param {String} [options.metricsContext.entrypoint] entrypoint identifier
-   *     @param {String} [options.metricsContext.migration] migration identifier
-   *     @param {String} [options.metricsContext.service] service identifier
-   *     @param {String} [options.metricsContext.utmCampaign] marketing campaign identifier
-   *     @param {String} [options.metricsContext.utmContent] marketing campaign content identifier
-   *     @param {String} [options.metricsContext.utmMedium] marketing campaign medium
-   *     @param {String} [options.metricsContext.utmSource] marketing campaign source
-   *     @param {String} [options.metricsContext.utmTerm] marketing campaign search term
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.accountReset = function(email, newPassword, accountResetToken, options) {
@@ -539,10 +527,6 @@ define([
     var unwrapBKey;
 
     options = options || {};
-
-    if (options.metricsContext) {
-      data.metricsContext = metricsContext.marshall(options.metricsContext);
-    }
 
     if (options.sessionToken) {
       data.sessionToken = options.sessionToken;
@@ -744,18 +728,6 @@ define([
    * @param {int} duration Time interval from now when the certificate will expire in milliseconds
    * @param {Object} [options={}] Options
    *   @param {String} [service=''] The requesting service, sent via the query string
-   *   @param {Object} [options.metricsContext={}] Metrics context metadata
-   *     @param {String} options.metricsContext.flowId identifier for the current event flow
-   *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
-   *     @param {String} [options.metricsContext.context] context identifier
-   *     @param {String} [options.metricsContext.entrypoint] entrypoint identifier
-   *     @param {String} [options.metricsContext.migration] migration identifier
-   *     @param {String} [options.metricsContext.service] service identifier
-   *     @param {String} [options.metricsContext.utmCampaign] marketing campaign identifier
-   *     @param {String} [options.metricsContext.utmContent] marketing campaign content identifier
-   *     @param {String} [options.metricsContext.utmMedium] marketing campaign medium
-   *     @param {String} [options.metricsContext.utmSource] marketing campaign source
-   *     @param {String} [options.metricsContext.utmTerm] marketing campaign search term
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.certificateSign = function(sessionToken, publicKey, duration, options) {
@@ -774,10 +746,6 @@ define([
     var queryString = '';
     if (options.service) {
       queryString = '?service=' + encodeURIComponent(options.service);
-    }
-
-    if (options.metricsContext) {
-      data.metricsContext = metricsContext.marshall(options.metricsContext);
     }
 
     return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)

--- a/tests/lib/account.js
+++ b/tests/lib/account.js
@@ -167,56 +167,6 @@ define([
           );
       });
 
-      test('#reset password with metricsContext metadata', function () {
-        var account, passwordForgotToken;
-
-        return accountHelper.newVerifiedAccount()
-          .then(function (a) {
-            account = a;
-            return respond(
-              client.passwordForgotSendCode(account.input.email),
-              RequestMocks.passwordForgotSendCode
-            );
-          })
-          .then(function (result) {
-            passwordForgotToken = result.passwordForgotToken;
-            return respond(mail.wait(account.input.user, 3), RequestMocks.resetMail);
-          })
-          .then(function (emails) {
-            var code = emails[2].html.match(/code=([A-Za-z0-9]+)/)[1];
-            return respond(
-              client.passwordForgotVerifyCode(code, passwordForgotToken),
-              RequestMocks.passwordForgotVerifyCode
-            );
-          })
-          .then(function (result) {
-            return respond(
-              client.accountReset(account.input.email, 'newpassword', result.accountResetToken),
-              RequestMocks.accountReset,
-              {
-                context: 'foo',
-                entrypoint: 'bar',
-                flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-                flowBeginTime: Date.now(),
-                forbiddenProperty: 'baz',
-                migration: 'qux',
-                service: 'wibble',
-                utmCampaign: 'blee',
-                utmContent: 'ugg',
-                utmMedium: 'fring',
-                utmSource: 'groz',
-                utmTerm: 'tarb'
-              }
-            );
-          })
-          .then(
-            function (result) {
-              assert.ok(result);
-            },
-            assert.notOk
-          );
-      });
-
       test('#passwordForgotSendCode with service, redirectTo, and resume', function () {
         var account;
         var opts = {

--- a/tests/lib/certificateSign.js
+++ b/tests/lib/certificateSign.js
@@ -44,6 +44,31 @@ define([
           );
       });
 
+      test('#with service option', function () {
+        return accountHelper.newVerifiedAccount()
+          .then(function (account) {
+            var publicKey = {
+              algorithm: 'RS',
+              n: '4759385967235610503571494339196749614544606692567785790953934768202714280652973091341316862993582789079872007974809511698859885077002492642203267408776123',
+              e: '65537'
+            };
+            var duration = 86400000;
+
+            return respond(
+              client.certificateSign(account.signIn.sessionToken, publicKey, duration, {
+                service: 'wibble'
+              }),
+              RequestMocks.certificateSign
+            );
+          })
+          .then(
+            function(res) {
+              assert.ok(res);
+            },
+            assert.notOk
+          );
+      });
+
       test('#with metricsContext metadata', function () {
         return accountHelper.newVerifiedAccount()
           .then(function (account) {

--- a/tests/lib/certificateSign.js
+++ b/tests/lib/certificateSign.js
@@ -68,35 +68,6 @@ define([
             assert.notOk
           );
       });
-
-      test('#with metricsContext metadata', function () {
-        return accountHelper.newVerifiedAccount()
-          .then(function (account) {
-            var publicKey = {
-              algorithm: 'RS',
-              n: '4759385967235610503571494339196749614544606692567785790953934768202714280652973091341316862993582789079872007974809511698859885077002492642203267408776123',
-              e: '65537'
-            };
-            var duration = 86400000;
-
-            return respond(
-              client.certificateSign(account.signIn.sessionToken, publicKey, duration, {
-                metricsContext: {
-                  flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-                  flowBeginTime: Date.now(),
-                  forbiddenProperty: 666
-                }
-              }),
-              RequestMocks.certificateSign
-            );
-          })
-          .then(
-            function(res) {
-              assert.ok(res);
-            },
-            assert.notOk
-          );
-      });
     });
   }
 });


### PR DESCRIPTION
There are two changes here, both related to the discussion in https://github.com/mozilla/fxa-auth-server/issues/1345:

1. A `service` option is added to `certificateSign`, which adds a `service` parameter to the query string. This enables us to properly fix the issue of spurious placeholder devices discussed in https://github.com/mozilla/fxa-content-server/issues/3933.

2. The `metricsContext` option is removed from `accountReset` and `certificateSign`, as they're about to be removed from the auth server for https://github.com/mozilla/fxa-auth-server/issues/1345. I've verified that the content server never passes it to those methods and nor should other clients be doing that.

@shane-tomlinson, low-priority r?