### PR TITLE
refactor(password): Send session id on password change

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -911,11 +911,17 @@ define([
     required(keys, 'keys');
     required(keys.kB, 'keys.kB');
 
-    var p1 = credentials.setup(email, newPassword);
-    var p2 = hawkCredentials(oldCreds.passwordChangeToken, 'passwordChangeToken',  HKDF_SIZE);
+    var defers = []
+    defers.push(credentials.setup(email, newPassword));
+    defers.push(hawkCredentials(oldCreds.passwordChangeToken, 'passwordChangeToken',  HKDF_SIZE));
 
-    return P.all([p1, p2])
-      .spread(function(newCreds, hawkCreds) {
+    if (options.sessionToken) {
+      // Unbundle session data to get session id
+      defers.push(hawkCredentials(options.sessionToken, 'sessionToken',  HKDF_SIZE))
+    }
+
+    return P.all(defers)
+      .spread(function(newCreds, hawkCreds, sessionData) {
         var newWrapKb = sjcl.codec.hex.fromBits(
           credentials.xor(
             sjcl.codec.hex.toBits(keys.kB),
@@ -928,17 +934,22 @@ define([
           queryParams = '?keys=true';
         }
 
+        var sessionTokenId = undefined
+        if (sessionData && sessionData.id) {
+          sessionTokenId = sessionData.id
+        }
+
         return self.request.send('/password/change/finish' + queryParams, 'POST', hawkCreds, {
-          wrapKb: newWrapKb,
-          authPW: sjcl.codec.hex.fromBits(newCreds.authPW),
-          sessionToken: options.sessionToken
-        })
-        .then(function (accountData) {
-          if (options.keys && accountData.keyFetchToken) {
-            accountData.unwrapBKey = sjcl.codec.hex.fromBits(newCreds.unwrapBKey);
-          }
-          return accountData;
-        });
+            wrapKb: newWrapKb,
+            authPW: sjcl.codec.hex.fromBits(newCreds.authPW),
+            sessionToken: sessionTokenId
+          })
+          .then(function (accountData) {
+            if (options.keys && accountData.keyFetchToken) {
+              accountData.unwrapBKey = sjcl.codec.hex.fromBits(newCreds.unwrapBKey);
+            }
+            return accountData;
+          });
       });
   };
 

--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -911,17 +911,17 @@ define([
     required(keys, 'keys');
     required(keys.kB, 'keys.kB');
 
-    var defers = []
+    var defers = [];
     defers.push(credentials.setup(email, newPassword));
     defers.push(hawkCredentials(oldCreds.passwordChangeToken, 'passwordChangeToken',  HKDF_SIZE));
 
     if (options.sessionToken) {
       // Unbundle session data to get session id
-      defers.push(hawkCredentials(options.sessionToken, 'sessionToken',  HKDF_SIZE))
+      defers.push(hawkCredentials(options.sessionToken, 'sessionToken',  HKDF_SIZE));
     }
 
     return P.all(defers)
-      .spread(function(newCreds, hawkCreds, sessionData) {
+      .spread(function (newCreds, hawkCreds, sessionData) {
         var newWrapKb = sjcl.codec.hex.fromBits(
           credentials.xor(
             sjcl.codec.hex.toBits(keys.kB),
@@ -934,22 +934,22 @@ define([
           queryParams = '?keys=true';
         }
 
-        var sessionTokenId = undefined
+        var sessionTokenId;
         if (sessionData && sessionData.id) {
-          sessionTokenId = sessionData.id
+          sessionTokenId = sessionData.id;
         }
 
         return self.request.send('/password/change/finish' + queryParams, 'POST', hawkCreds, {
-            wrapKb: newWrapKb,
-            authPW: sjcl.codec.hex.fromBits(newCreds.authPW),
-            sessionToken: sessionTokenId
-          })
-          .then(function (accountData) {
-            if (options.keys && accountData.keyFetchToken) {
-              accountData.unwrapBKey = sjcl.codec.hex.fromBits(newCreds.unwrapBKey);
-            }
-            return accountData;
-          });
+          wrapKb: newWrapKb,
+          authPW: sjcl.codec.hex.fromBits(newCreds.authPW),
+          sessionToken: sessionTokenId
+        })
+        .then(function (accountData) {
+          if (options.keys && accountData.keyFetchToken) {
+            accountData.unwrapBKey = sjcl.codec.hex.fromBits(newCreds.unwrapBKey);
+          }
+          return accountData;
+        });
       });
   };
 


### PR DESCRIPTION
This PR updates the fxa-client to send the session id instead of session data to the auth server. This fix does not require any updates to the content-server because existing pattern is to send session data to fxa-client. Auth-server changes to support this were merged [here](https://github.com/mozilla/fxa-auth-server/pull/1302)

Fixes https://github.com/mozilla/fxa-content-server/issues/3875