### PR TITLE
refactor(signin): Remove `sendEmailIfUnverified` from client

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -168,9 +168,6 @@ define([
    * @param {Object} [options={}] Options
    *   @param {Boolean} [options.keys]
    *   If `true`, calls the API with `?keys=true` to get the keyFetchToken
-   *   @param {Boolean} [options.sendEmailIfUnverified]
-   *   If `true`, calls the API with `?sendEmailIfUnverified=true` and delegates sending emails
-   *   to the auth-server.
    *   @param {Boolean} [options.skipCaseError]
    *   If `true`, the request will skip the incorrect case error
    *   @param {String} [options.service]
@@ -212,16 +209,8 @@ define([
         function (result) {
           var endpoint = '/account/login';
 
-          // If not specified, always default `sendEmailIfUnverified` to false.
-          // This is what the legacy auth-server expects. Can remove once
-          // https://github.com/mozilla/fxa-auth-server/issues/1451 lands.
-          if (!options.sendEmailIfUnverified) {
-            options.sendEmailIfUnverified = false;
-          }
-          endpoint = endpoint + '?sendEmailIfUnverified=' + options.sendEmailIfUnverified;
-
           if (options.keys) {
-            endpoint += '&keys=true';
+            endpoint += '?keys=true';
           }
 
           var data = {

--- a/tests/lib/signIn.js
+++ b/tests/lib/signIn.js
@@ -63,23 +63,6 @@ define([
           );
       });
 
-      test('#with sendEmailIfUnverified', function () {
-        var email = 'test' + new Date().getTime() + '@restmail.net';
-        var password = 'iliketurtles';
-
-        return respond(client.signUp(email, password), RequestMocks.signUp)
-          .then(function (res) {
-            return respond(client.signIn(email, password, {sendEmailIfUnverified: true}), RequestMocks.signInEmailSent);
-          })
-          .then(
-            function (res) {
-              assert.ok(res.sessionToken);
-              assert.equal(res.emailSent, true);
-            },
-            assert.notOk
-          );
-      });
-
       test('#with service', function () {
         var email = 'test' + new Date().getTime() + '@restmail.net';
         var password = 'iliketurtles';


### PR DESCRIPTION
Since https://github.com/mozilla/fxa-auth-server/issues/1451 has landed, the auth-server ignores `sendEmailIfUnverified`.