### PR TITLE
fix(client): propagate metrics context data to /account/reset

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -530,6 +530,9 @@ define([
    *   is required if `options.keys` is true.
    *   @param {Boolean} [options.sessionToken]
    *   If `true`, a new `sessionToken` is provisioned.
+   *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.flowId identifier for the current event flow
+   *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.accountReset = function(email, newPassword, accountResetToken, options) {
@@ -541,6 +544,10 @@ define([
 
     if (options.sessionToken) {
       data.sessionToken = options.sessionToken;
+    }
+
+    if (options.metricsContext) {
+      data.metricsContext = metricsContext.marshall(options.metricsContext);
     }
 
     required(email, 'email');

--- a/tests/lib/account.js
+++ b/tests/lib/account.js
@@ -154,7 +154,14 @@ define([
             var newPassword = 'newturles';
             assert.ok(accountResetToken, 'accountResetToken is returned');
 
-            return respond(client.accountReset(email, newPassword, accountResetToken, { keys: true, sessionToken: true }), RequestMocks.accountReset);
+            return respond(client.accountReset(email, newPassword, accountResetToken, {
+              keys: true,
+              metricsContext: {
+                flowBeginTime: 1480615985437,
+                flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+              },
+              sessionToken: true
+            }), RequestMocks.accountReset);
           })
           .then(
             function (result) {


### PR DESCRIPTION
Fixes #225.

@vladikoff r?