### PR TITLE
feat(sms): Add support for sending sms messages

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -1170,9 +1170,10 @@ define([
       }
     }
 
+    var request = this.request;
     return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function(creds) {
-        return this.request.send('/sms', 'POST', creds, data, requestOpts);
+        return request.send('/sms', 'POST', creds, data, requestOpts);
       });
   };
 

--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -1134,6 +1134,49 @@ define([
   };
 
   /**
+   * Send an sms.
+   *
+   * @method sendSms
+   * @param {String} sessionToken SessionToken obtained from signIn
+   * @param {String} phoneNumber Phone number sms will be sent to
+   * @param {String} messageId Corresponding message id that will be sent
+   * @param {Object} [options={}] Options
+   *   @param {String} [options.lang] lang Language that sms will be sent in
+   *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.flowId identifier for the current event flow
+   *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
+   */
+  FxAccountClient.prototype.sendSms = function (sessionToken, phoneNumber, messageId, options) {
+
+    required(sessionToken, 'sessionToken');
+    required(phoneNumber, 'phoneNumber');
+    required(messageId, 'messageId');
+
+    var data = {
+      phoneNumber: phoneNumber,
+      messageId: messageId
+    };
+    var requestOpts = {};
+
+    if (options) {
+      if (options.lang) {
+        requestOpts.headers = {
+          'Accept-Language': options.lang
+        };
+      }
+
+      if (options.metricsContext) {
+        data.metricsContext = metricsContext.marshall(options.metricsContext);
+      }
+    }
+
+    return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
+      .then(function(creds) {
+        return this.request.send('/sms', 'POST', creds, data, requestOpts);
+      });
+  };
+
+  /**
    * Check for a required argument. Exposed for unit testing.
    *
    * @param {Value} val - value to check

--- a/tests/all.js
+++ b/tests/all.js
@@ -20,6 +20,7 @@ define([
   'tests/lib/session',
   'tests/lib/signIn',
   'tests/lib/signUp',
+  'tests/lib/sms',
   'tests/lib/unbundle',
   'tests/lib/uriVersion',
   'tests/lib/verifyCode'

--- a/tests/lib/sms.js
+++ b/tests/lib/sms.js
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!tdd',
+  'intern/chai!assert',
+  'tests/addons/environment',
+  'tests/lib/push-constants'
+], function (tdd, assert, Environment) {
+
+  var PHONE_NUMBER = '14071234567';
+  var INVITE_USER_MESSAGE_ID = '1';
+
+  with (tdd) {
+    suite('sms', function () {
+      var accountHelper;
+      var respond;
+      var client;
+      var RequestMocks;
+
+      beforeEach(function () {
+        var env = new Environment();
+        accountHelper = env.accountHelper;
+        respond = env.respond;
+        client = env.client;
+        RequestMocks = env.RequestMocks;
+      });
+
+      test('#send connect device', function () {
+
+        return accountHelper.newVerifiedAccount()
+          .then(function (account) {
+
+            return respond(client.sendSms(
+              account.signIn.sessionToken,
+              PHONE_NUMBER,
+              INVITE_USER_MESSAGE_ID
+            ), RequestMocks.sendSmsConnectDevice);
+          })
+          .then(
+            function(res) {
+              // TODO Define the actual response
+              assert.equal(res.phoneNumber, PHONE_NUMBER);
+              assert.equal(res.messageId, INVITE_USER_MESSAGE_ID);
+              assert.equal(res.sent, true);
+            },
+            function (err) {
+              console.log(err);
+              assert.notOk();
+            }
+          );
+      });
+    });
+  }
+});
+

--- a/tests/lib/sms.js
+++ b/tests/lib/sms.js
@@ -9,8 +9,11 @@ define([
   'tests/lib/push-constants'
 ], function (tdd, assert, Environment) {
 
-  var PHONE_NUMBER = '14071234567';
-  var INVITE_USER_MESSAGE_ID = '1';
+  // These tests are intended to run against a mock auth-server. To test
+  // against a local auth-server, you will need to have it correctly
+  // configured to send sms and specify a real phone number here.
+  var PHONE_NUMBER = '+14071234567';
+  var MESSAGE_ID = 1;
 
   with (tdd) {
     suite('sms', function () {
@@ -35,20 +38,14 @@ define([
             return respond(client.sendSms(
               account.signIn.sessionToken,
               PHONE_NUMBER,
-              INVITE_USER_MESSAGE_ID
+              MESSAGE_ID
             ), RequestMocks.sendSmsConnectDevice);
           })
           .then(
-            function(res) {
-              // TODO Define the actual response
-              assert.equal(res.phoneNumber, PHONE_NUMBER);
-              assert.equal(res.messageId, INVITE_USER_MESSAGE_ID);
-              assert.equal(res.sent, true);
+            function (resp) {
+              assert.ok(resp);
             },
-            function (err) {
-              console.log(err);
-              assert.notOk();
-            }
+            assert.notOk
           );
       });
     });

--- a/tests/lib/sms.js
+++ b/tests/lib/sms.js
@@ -12,6 +12,11 @@ define([
   // These tests are intended to run against a mock auth-server. To test
   // against a local auth-server, you will need to have it correctly
   // configured to send sms and specify a real phone number here.
+  var env = new Environment();
+  if (env.useRemoteServer) {
+    return;
+  }
+
   var PHONE_NUMBER = '+14071234567';
   var MESSAGE_ID = 1;
 
@@ -23,7 +28,7 @@ define([
       var RequestMocks;
 
       beforeEach(function () {
-        var env = new Environment();
+        env = new Environment();
         accountHelper = env.accountHelper;
         respond = env.respond;
         client = env.client;

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -254,6 +254,10 @@ define([
     rejectUnblockCode: {
       status: 200,
       body: '{}'
+    },
+    sendSmsConnectDevice: {
+      status: 200,
+      body: '{"phoneNumber":"14071234567","messageId":"1", "sent": true}'
     }
   };
 });

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -257,7 +257,7 @@ define([
     },
     sendSmsConnectDevice: {
       status: 200,
-      body: '{"phoneNumber":"14071234567","messageId":"1", "sent": true}'
+      body: '{}'
     }
   };
 });


### PR DESCRIPTION
This PR adds support for sending sms messages from the js client. The responses and request values will be changing as the api becomes defined.

Connects with https://github.com/mozilla/fxa-features/issues/53, https://github.com/mozilla/fxa-auth-server/issues/1628