### PR TITLE
feat(sms): Add a `country` option to `/sms/status` endpoint

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -1207,14 +1207,23 @@ define([
    *
    * @method smsStatus
    * @param {String} sessionToken SessionToken obtained from signIn
+   * @param {Object} [options={}] Options
+   *   @param {String} [options.country] country Country to force. Will be used to test
+   *     whether SMS is available and returned in `country` field.
    */
-  FxAccountClient.prototype.smsStatus = function (sessionToken) {
+  FxAccountClient.prototype.smsStatus = function (sessionToken, options) {
     required(sessionToken, 'sessionToken');
+
+    options = options || {};
 
     var request = this.request;
     return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE)
       .then(function (creds) {
-        return request.send('/sms/status', 'GET', creds);
+        var url = '/sms/status';
+        if (options.country) {
+          url += '?country=' + encodeURIComponent(options.country);
+        }
+        return request.send(url, 'GET', creds);
       });
   };
 

--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -1208,8 +1208,7 @@ define([
    * @method smsStatus
    * @param {String} sessionToken SessionToken obtained from signIn
    * @param {Object} [options={}] Options
-   *   @param {String} [options.country] country Country to force. Will be used to test
-   *     whether SMS is available and returned in `country` field.
+   *   @param {String} [options.country] country Country to force for testing.
    */
   FxAccountClient.prototype.smsStatus = function (sessionToken, options) {
     required(sessionToken, 'sessionToken');

--- a/tests/lib/sms.js
+++ b/tests/lib/sms.js
@@ -68,6 +68,27 @@ define([
             function (resp) {
               assert.ok(resp);
               assert.ok(resp.ok);
+              assert.ok(resp.country);
+            },
+            assert.notOk
+          );
+      });
+
+      test('status with country', function () {
+        return accountHelper.newVerifiedAccount()
+          .then(
+            function (account) {
+              return respond(
+                client.smsStatus(account.signIn.sessionToken, { country: 'RO' }),
+                RequestMocks.smsStatus
+              );
+            }
+          )
+          .then(
+            function (resp) {
+              assert.ok(resp);
+              assert.ok(resp.ok);
+              assert.ok(resp.country, 'RO');
             },
             assert.notOk
           );

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -284,7 +284,7 @@ define([
     },
     smsStatus: {
       status: 200,
-      body: '{"ok":true}'
+      body: '{"country":"RO","ok":true}'
     }
   };
 });


### PR DESCRIPTION
@philbooth - r?

issue mozilla/fxa-content-server#4861
blocks https://github.com/mozilla/fxa-content-server/pull/4872

