### PR TITLE
feat(client): implement consumeSigninCode for POST /signinCodes/consume

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -1178,7 +1178,8 @@ define([
    * @param {String} phoneNumber Phone number sms will be sent to
    * @param {String} messageId Corresponding message id that will be sent
    * @param {Object} [options={}] Options
-   *   @param {String} [options.lang] lang Language that sms will be sent in
+   *   @param {String} [options.lang] Language that sms will be sent in
+   *   @param {Array} [options.features] Array of features to be enabled for the request
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
@@ -1200,6 +1201,10 @@ define([
         requestOpts.headers = {
           'Accept-Language': options.lang
         };
+      }
+
+      if (options.features) {
+        data.features = options.features;
       }
 
       if (options.metricsContext) {
@@ -1236,6 +1241,28 @@ define([
         }
         return request.send(url, 'GET', creds);
       });
+  };
+
+  /**
+   * Consume a signinCode.
+   *
+   * @method consumeSigninCode
+   * @param {String} code The signinCode entered by the user
+   * @param {String} flowId Identifier for the current event flow
+   * @param {Number} flowBeginTime Timestamp for the flow.begin event
+   */
+  FxAccountClient.prototype.consumeSigninCode = function (code, flowId, flowBeginTime) {
+    required(code, 'code');
+    required(flowId, 'flowId');
+    required(flowBeginTime, 'flowBeginTime');
+
+    return this.request.send('/signinCodes/consume', 'POST', null, {
+      code: code,
+      metricsContext: {
+        flowId: flowId,
+        flowBeginTime: flowBeginTime
+      }
+    });
   };
 
   /**

--- a/tests/all.js
+++ b/tests/all.js
@@ -20,6 +20,7 @@ define([
   'tests/lib/request',
   'tests/lib/session',
   'tests/lib/signIn',
+  'tests/lib/signinCodes',
   'tests/lib/signUp',
   'tests/lib/sms',
   'tests/lib/unbundle',

--- a/tests/lib/signinCodes.js
+++ b/tests/lib/signinCodes.js
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var SIGNIN_CODE = '123456-_';
+var FLOW_ID = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+var FLOW_BEGIN_TIME = Date.now();
+
+define([
+  'intern!tdd',
+  'intern/chai!assert',
+  'tests/addons/environment'
+], function (tdd, assert, Environment) {
+  var env = new Environment();
+
+  with (tdd) {
+    suite('signinCodes', function () {
+      var respond;
+      var client;
+      var RequestMocks;
+
+      beforeEach(function () {
+        env = new Environment();
+        respond = env.respond;
+        client = env.client;
+        RequestMocks = env.RequestMocks;
+      });
+
+      if (env.useRemoteServer) {
+        // This test is intended to run against a local auth-server. To test
+        // against a mock auth-server would be pointless for this assertion.
+        test('consumeSigninCode with invalid signinCode', function () {
+          return client.consumeSigninCode(SIGNIN_CODE, FLOW_ID, FLOW_BEGIN_TIME)
+            .then(function () {
+              assert.fail('client.consumeSigninCode should throw if signinCode is invalid');
+            }, function (err) {
+              assert.ok(err, 'client.consumeSigninCode should return an error');
+              assert.equal(err.code, 400, 'client.consumeSigninCode should return a 400 response');
+              assert.equal(err.errno, 146, 'client.consumeSigninCode should return errno 146');
+            });
+        });
+      } else {
+        // This test is intended to run against a mock auth-server. To test
+        // against a local auth-server, we'd need to know a valid signinCode.
+        test('consumeSigninCode', function () {
+          return respond(client.consumeSigninCode(SIGNIN_CODE, FLOW_ID, FLOW_BEGIN_TIME), RequestMocks.consumeSigninCode)
+            .then(assert.ok, assert.fail);
+        });
+      }
+
+
+      test('consumeSigninCode with missing signinCode', function () {
+        var completed = false;
+        try {
+          client.consumeSigninCode(null, FLOW_ID, FLOW_BEGIN_TIME);
+          completed = true;
+        } catch (err) {
+          assert.ok(err);
+        }
+        assert.notOk(completed, 'client.consumeSigninCode should throw if signinCode is missing');
+      });
+
+      test('consumeSigninCode with missing flowId', function () {
+        var completed = false;
+        try {
+          client.consumeSigninCode(SIGNIN_CODE, null, FLOW_BEGIN_TIME);
+          completed = true;
+        } catch (err) {
+          assert.ok(err);
+        }
+        assert.notOk(completed, 'client.consumeSigninCode should throw if flowId is missing');
+      });
+
+      test('consumeSigninCode with missing flowBeginTime', function () {
+        var completed = false;
+        try {
+          client.consumeSigninCode(SIGNIN_CODE, FLOW_ID, null);
+          completed = true;
+        } catch (err) {
+          assert.ok(err);
+        }
+        assert.notOk(completed, 'client.consumeSigninCode should throw if flowBeginTime is missing');
+      });
+    });
+  }
+});
+

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -290,6 +290,10 @@ define([
       status: 200,
       body: '{"country":"RO","ok":true}'
     },
+    consumeSigninCode: {
+      status: 200,
+      body: '{"email":"foo@example.org"}'
+    },
     recoveryEmails: {
       status: 200,
       body: '[{"email": "a@b.com", "isVerified": true, "isPrimary": true}]'


### PR DESCRIPTION
Fixes #242. Matches the endpoint being added to the auth server in mozilla/fxa-auth-server#1906.

@mozilla/fxa-devs r?
