### PR TITLE
feat(emails): Expose client endpoints for detecting if secondary emails

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -1452,6 +1452,26 @@ define([
   };
 
   /**
+   * Check to see if the secondary email feature is enabled for this user.
+   *
+   * @method recoveryEmailSecondaryEmailEnabled
+   * @param {String} sessionToken SessionToken obtained from signIn
+   */
+  FxAccountClient.prototype.recoveryEmailSecondaryEmailEnabled = function (sessionToken) {
+    var request = this.request;
+
+    return P()
+      .then(function () {
+        required(sessionToken, 'sessionToken');
+
+        return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE);
+      })
+      .then(function(creds) {
+        return request.send('/recovery_email/check_can_add_secondary_address', 'GET', creds);
+      });
+  };
+
+  /**
    * Check for a required argument. Exposed for unit testing.
    *
    * @param {Value} val - value to check

--- a/tests/addons/accountHelper.js
+++ b/tests/addons/accountHelper.js
@@ -13,10 +13,13 @@ define([
     this.mail = mail;
     this.respond = respond;
   }
+  AccountHelper.prototype.newVerifiedAccount = function (emailDomain) {
+    if (! emailDomain) {
+      emailDomain = '@restmail.net';
+    }
 
-  AccountHelper.prototype.newVerifiedAccount = function () {
     var user = 'testHelp1' + new Date().getTime();
-    var email = user + '@restmail.net';
+    var email = user + emailDomain;
     var password = 'iliketurtles';
     var respond = this.respond;
     var mail = this.mail;
@@ -55,9 +58,13 @@ define([
       });
   };
 
-  AccountHelper.prototype.newUnverifiedAccount = function () {
+  AccountHelper.prototype.newUnverifiedAccount = function (emailDomain) {
+    if (! emailDomain) {
+      emailDomain = '@restmail.net';
+    }
+
     var user = 'testHelp2' + new Date().getTime();
-    var email = user + '@restmail.net';
+    var email = user + emailDomain;
     var password = 'iliketurtles';
     var respond = this.respond;
     var client = this.client;

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -313,6 +313,14 @@ define([
     recoveryEmailDestroy: {
       status: 200,
       body: '{}'
+    },
+    recoveryEmailSecondaryEmailEnabledTrue: {
+      status: 200,
+      body: '{"ok":true}'
+    },
+    recoveryEmailSecondaryEmailEnabledFalse: {
+      status: 200,
+      body: '{"ok":false}'
     }
   };
 });


### PR DESCRIPTION
This PR adds support to the js client for checking whether or not secondary emails is enabled for a particular user. The feature is considered enabled if their email matches the regex on auth-server and if they are in a verified session.