### PR TITLE
feat(client): move marketingOptIn parameter to verifyCode

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -96,8 +96,6 @@ define([
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
-   *   @param {Boolean} [options.marketingOptIn]
-   *   If `true`, sends opt-in desire for when account is verified.
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.signUp = function (email, password, options) {
@@ -150,10 +148,6 @@ define([
 
             if (options.metricsContext) {
               data.metricsContext = metricsContext.marshall(options.metricsContext);
-            }
-
-            if (options.marketingOptIn) {
-              data.marketingOptIn = true;
             }
           }
 
@@ -278,6 +272,8 @@ define([
    *   Reminder that was used to verify the account
    *   @param {String} [options.type]
    *   Type of code being verified, only supports `secondary` otherwise will verify account/sign-in
+   *   @param {Boolean} [options.marketingOptIn]
+   *   If `true`, notifies marketing of opt-in intent.
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.verifyCode = function(uid, code, options) {
@@ -304,6 +300,10 @@ define([
 
           if (options.type) {
             data.type = options.type;
+          }
+
+          if (options.marketingOptIn) {
+            data.marketingOptIn = true;
           }
         }
 

--- a/tests/lib/session.js
+++ b/tests/lib/session.js
@@ -83,7 +83,6 @@ define([
               assert.equal(res.length, 2);
               var s = res[0];
               assert.ok(s.id);
-              assert.ok(s.userAgent);
               assert.ok(s.deviceName);
               assert.ok(s.deviceType);
               assert.equal(s.isDevice, false);

--- a/tests/lib/signUp.js
+++ b/tests/lib/signUp.js
@@ -255,29 +255,6 @@ define([
           assert.notOk
         );
       });
-
-      test('#with marketingOptIn', function () {
-        var email = 'test' + new Date().getTime() + '@restmail.net';
-        var password = 'iliketurtles';
-
-        return respond(
-          client.signUp(email, password, {
-            marketingOptIn: true
-          }),
-          RequestMocks.signUp
-        )
-        .then(
-          function (resp) {
-            assert.ok(resp);
-
-            assert.equal(xhrOpen.args[0][0], 'POST', 'method is correct');
-            assert.include(xhrOpen.args[0][1], '/account/create', 'path is correct');
-            var sentData = JSON.parse(xhrSend.args[0][0]);
-            assert.equal(sentData.marketingOptIn, true);
-          },
-          assert.notOk
-        );
-      });
     });
   }
 });


### PR DESCRIPTION
This skips the need for the auth-server to keep a fragile cache of opt-in intents. Blocked on https://github.com/mozilla/fxa-auth-server/pull/1984