### PR TITLE
feat(api): add deviceId to metricsContext data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ notifications:
     on_failure: change
 
 node_js:
-  - "4"
   - "6"
 
 addons:

--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -94,6 +94,7 @@ define([
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -185,6 +186,7 @@ define([
    *   as a querystring parameter, useful for continuing an OAuth flow for
    *   example.
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    *   @param {String} [options.unblockCode]
@@ -413,6 +415,7 @@ define([
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -475,6 +478,7 @@ define([
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -531,6 +535,7 @@ define([
    * @param {String} code
    * @param {String} passwordForgotToken
    * @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -595,6 +600,7 @@ define([
    *   @param {Boolean} [options.sessionToken]
    *   If `true`, a new `sessionToken` is provisioned.
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -1235,6 +1241,7 @@ define([
    * @param {String} email email where to send the login authorization code
    * @param {Object} [options={}] Options
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -1295,6 +1302,7 @@ define([
    *   @param {String} [options.lang] Language that sms will be sent in
    *   @param {Array} [options.features] Array of features to be enabled for the request
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
+   *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
    *     @param {Number} options.metricsContext.flowBeginTime flow.begin event time
    */
@@ -1370,8 +1378,9 @@ define([
    * @param {String} code The signinCode entered by the user
    * @param {String} flowId Identifier for the current event flow
    * @param {Number} flowBeginTime Timestamp for the flow.begin event
+   * @param {String} [deviceId] Identifier for the current device
    */
-  FxAccountClient.prototype.consumeSigninCode = function (code, flowId, flowBeginTime) {
+  FxAccountClient.prototype.consumeSigninCode = function (code, flowId, flowBeginTime, deviceId) {
     var self = this;
 
     return P()
@@ -1383,6 +1392,7 @@ define([
         return self.request.send('/signinCodes/consume', 'POST', null, {
           code: code,
           metricsContext: {
+            deviceId: deviceId,
             flowId: flowId,
             flowBeginTime: flowBeginTime
           }

--- a/client/lib/metricsContext.js
+++ b/client/lib/metricsContext.js
@@ -11,6 +11,7 @@ define([], function () {
   return {
     marshall: function (data) {
       return {
+        deviceId: data.deviceId,
         flowId: data.flowId,
         flowBeginTime: data.flowBeginTime
       };

--- a/tests/lib/account.js
+++ b/tests/lib/account.js
@@ -156,6 +156,7 @@ define([
             return respond(client.accountReset(email, newPassword, accountResetToken, {
               keys: true,
               metricsContext: {
+                deviceId: '0123456789abcdef0123456789abcdef',
                 flowBeginTime: 1480615985437,
                 flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
               },

--- a/tests/lib/metricsContext.js
+++ b/tests/lib/metricsContext.js
@@ -19,6 +19,7 @@ define([
     t.test('marshall returns correct data', function () {
       var input = {
         context: 'fx_desktop_v3',
+        deviceId: '0123456789abcdef0123456789abcdef',
         entrypoint: 'menupanel',
         flowBeginTime: 1479815991573,
         flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -32,6 +33,7 @@ define([
       };
 
       assert.deepEqual(metricsContext.marshall(input), {
+        deviceId: input.deviceId,
         flowBeginTime: input.flowBeginTime,
         flowId: input.flowId
       });

--- a/tests/lib/signUp.js
+++ b/tests/lib/signUp.js
@@ -241,6 +241,7 @@ define([
         return respond(
           client.signUp(email, password, {
             metricsContext: {
+              deviceId: '0123456789abcdef0123456789abcdef',
               flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
               flowBeginTime: Date.now(),
               forbiddenProperty: 666


### PR DESCRIPTION
Related to mozilla/fxa-auth-server#2072.

Adds a `deviceId` property to `metricsContext`.

Includes a preliminary fix to disable node 4 tests against a real auth server instance, because the auth server doesn't run in node 4 any more. Of course we could just disable tests on node 4 entirely, too. But there's nothing in this repo that requires it, the mock tests could even run against 0.10 if we wanted?

@mozilla/fxa-devs r?