### PR TITLE
feat(session): Pass `options.type` to recoveryEmailResendCode

### DIFF
--- a/client/FxAccountClient.js
+++ b/client/FxAccountClient.js
@@ -363,6 +363,9 @@ define([
    *   Opaque url-encoded string that will be included in the verification link
    *   as a querystring parameter, useful for continuing an OAuth flow for
    *   example.
+   *   @param {String} [options.type]
+   *   Specifies the type of code to send, currently only supported type is
+   *   `upgradeSession`.
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
@@ -391,6 +394,10 @@ define([
 
           if (options.resume) {
             data.resume = options.resume;
+          }
+
+          if (options.type) {
+            data.type = options.type;
           }
 
           if (options.lang) {

--- a/tests/lib/recoveryEmail.js
+++ b/tests/lib/recoveryEmail.js
@@ -50,12 +50,13 @@ define([
           );
       });
 
-      test('#recoveryEmailResendCode with service, redirectTo, and resume', function () {
+      test('#recoveryEmailResendCode with service, redirectTo, type, and resume', function () {
         var user;
         var opts = {
           service: 'sync',
           redirectTo: 'https://sync.firefox.com/after_reset',
-          resume: 'resumejwt'
+          resume: 'resumejwt',
+          type: 'upgradeSession'
         };
 
         return accountHelper.newUnverifiedAccount()


### PR DESCRIPTION
Fixes #265 