### PR TITLE
feat(recovery): initial support for account recovery

### DIFF
--- a/tests/all.js
+++ b/tests/all.js
@@ -17,6 +17,7 @@ define([
   'tests/lib/misc',
   'tests/lib/passwordChange',
   'tests/lib/recoveryCodes',
+  'tests/lib/recoveryKeys',
   'tests/lib/recoveryEmail',
   'tests/lib/request',
   'tests/lib/session',

--- a/tests/lib/recoveryKeys.js
+++ b/tests/lib/recoveryKeys.js
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!tdd',
+  'intern/chai!assert',
+  'tests/addons/environment',
+  'tests/addons/sinon'
+], function (tdd, assert, Environment, sinon) {
+
+  with (tdd) {
+    suite('recovery keys', function () {
+      var account;
+      var accountHelper;
+      var respond;
+      var client;
+      var email;
+      var RequestMocks;
+      var env;
+      var xhr;
+      var xhrOpen;
+      var xhrSend;
+      var keys;
+      var passwordForgotToken;
+      var accountResetToken;
+      var mail;
+      var newPassword = '~(_8^(I)';
+      var recoveryKeyId = 'edc243a821582ee9e979583be9989ee7';
+      var bundle = 'eyJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIiwia2lkIjoiODE4NDIwZjBkYTU4ZDIwZjZhZTR' +
+        'kMmM5YmVhYjkyNTEifQ..D29EXHp8ubLvftaZ.xHJd2Nl2Uco2RyywYPLkUU7fHpgO2FztY12Zjpq1ffiyLRIUcQVfmiNC6aMiHB' +
+        'l7Hp-lXEbb5mR1uXHrTH9iRXEBVaAfyf9KEAWOukWGVSH8EaOkr7cfu2Yr0K93Ec8glsssjiKp8NGB8VKTUJ-lmBv2cIrG68V4eTUVDo' +
+        'DhMbXhrF-Mv4JNeh338pPeatTnyg.Ow2bhEYWxzxfSPMxVwKmSA';
+
+      beforeEach(function () {
+        env = new Environment();
+        accountHelper = env.accountHelper;
+        respond = env.respond;
+        client = env.client;
+        RequestMocks = env.RequestMocks;
+        mail = env.mail;
+
+        return accountHelper.newVerifiedAccount()
+          .then(function (newAccount) {
+            account = newAccount;
+            email = account.input.email;
+            return respond(client.accountKeys(account.signIn.keyFetchToken, account.signIn.unwrapBKey), RequestMocks.accountKeys);
+          })
+          .then(function (result) {
+            keys = result;
+            xhr = env.xhr;
+            xhrOpen = sinon.spy(xhr.prototype, 'open');
+            xhrSend = sinon.spy(xhr.prototype, 'send');
+          });
+      });
+
+      afterEach(function () {
+        xhrOpen.restore();
+        xhrSend.restore();
+      });
+
+      test('#can create and get a recovery key that can be used to reset an account', function () {
+        return respond(client.createRecoveryKey(account.signIn.sessionToken, recoveryKeyId, bundle), RequestMocks.createRecoveryKey)
+          .then(function () {
+            return respond(client.passwordForgotSendCode(email), RequestMocks.passwordForgotSendCode);
+          })
+          .then(function (result) {
+            passwordForgotToken = result.passwordForgotToken;
+            assert.ok(passwordForgotToken, 'passwordForgotToken is returned');
+
+            return respond(mail.wait(account.input.user, 3), RequestMocks.resetMailpasswordForgotRecoveryKey);
+          })
+          .then(function (emails) {
+            var code = emails[2].html.match(/code=([A-Za-z0-9]+)/)[1];
+            assert.ok(code, 'code is returned: ' + code);
+
+            return respond(client.passwordForgotVerifyCode(code, passwordForgotToken), RequestMocks.passwordForgotVerifyCode);
+          })
+          .then(function(result) {
+            accountResetToken = result.accountResetToken;
+            assert.ok(accountResetToken, 'accountResetToken is returned');
+
+            return respond(client.getRecoveryKey(accountResetToken, recoveryKeyId), RequestMocks.getRecoveryKey);
+          })
+          .then(function (res) {
+            assert.equal(xhrOpen.args[4][0], 'GET', 'method is correct');
+            assert.include(xhrOpen.args[4][1], '/recoveryKeys/' + recoveryKeyId, 'path is correct');
+            assert.ok(res.recoveryData, 'contains recovery data');
+
+            var options = {
+              keys: true,
+              metricsContext: {
+                deviceId: '0123456789abcdef0123456789abcdef',
+                flowBeginTime: 1480615985437,
+                flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+                utmCampaign: 'mock-campaign',
+                utmContent: 'mock-content',
+                utmMedium: 'mock-medium',
+                utmSource: 'mock-source',
+                utmTerm: 'mock-term'
+              },
+              sessionToken: true
+            };
+            return respond(client.resetPasswordWithRecoveryKey(accountResetToken, email, newPassword, recoveryKeyId, keys, options), RequestMocks.accountReset);
+          })
+          .then(function (res) {
+            assert.ok(res.keyFetchToken);
+            assert.ok(res.sessionToken);
+            assert.ok(res.unwrapBKey);
+            assert.ok(res.uid);
+
+            // Attempt to login with new password and retrieve keys
+            return respond(client.signIn(email, newPassword, {keys: true}), RequestMocks.signInWithKeys);
+          })
+          .then(function (res) {
+            return respond(client.accountKeys(res.keyFetchToken, res.unwrapBKey), RequestMocks.accountKeys);
+          })
+          .then(function (res) {
+            if (!env.useRemoteServer) {
+              assert.ok(res.kB, 'kB exists');
+            } else {
+              assert.equal(res.kB, keys.kB, 'kB is equal to original kB');
+            }
+          });
+      });
+    });
+  }
+});

--- a/tests/mocks/request.js
+++ b/tests/mocks/request.js
@@ -109,6 +109,10 @@ define([
       status: 200,
       body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001"}]'
     },
+    resetMailpasswordForgotRecoveryKey: {
+      status: 200,
+      body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001"}, {"html":"Mocked code=9001"}]'
+    },
     resetMailUnlock: {
       status: 200,
       body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001"}, {"html":"Mocked code=9001"}]'
@@ -396,6 +400,14 @@ define([
     replaceRecoveryCodesSuccessNew: {
       status: 200,
       body: '{"recoveryCodes": ["99999999", "01001113", "01001114", "01001115", "01001116", "01001117", "01001118", "01001119"]}'
+    },
+    createRecoveryKey: {
+      status: 200,
+      body: '{}'
+    },
+    getRecoveryKey: {
+      status: 200,
+      body: '{"recoveryData": "eyJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIiwia2lkIjoiODE4NDIwZjBkYTU4ZDIwZjZhZTRkMmM5YmVhYjkyNTEifQ..D29EXHp8ubLvftaZ.xHJd2Nl2Uco2RyywYPLkUU7fHpgO2FztY12Zjpq1ffiyLRIUcQVfmiNC6aMiHBl7Hp-lXEbb5mR1uXHrTH9iRXEBVaAfyf9KEAWOukWGVSH8EaOkr7cfu2Yr0K93Ec8glsssjiKp8NGB8VKTUJ-lmBv2cIrG68V4eTUVDoDhMbXhrF-Mv4JNeh338pPeatTnyg.Ow2bhEYWxzxfSPMxVwKmSA"}'
     }
   };
 });


### PR DESCRIPTION
blocked by https://github.com/mozilla/fxa-auth-server/issues/2421

- [x] Add/cleanup comments
- [ ] ~~Add test cases for `RecoveryKey` util~~
- [ ] ~~Add test cases that use an explicit input vector per https://gist.github.com/rfk/0462fc6c81e43f2b9abbea41c479a784~~