### PR TITLE
chore(metrics): reinstate entrypoint to metricsContext payload

### DIFF
--- a/client/lib/metricsContext.js
+++ b/client/lib/metricsContext.js
@@ -12,6 +12,7 @@ define([], function () {
     marshall: function (data) {
       return {
         deviceId: data.deviceId,
+        entrypoint: data.entrypoint,
         flowId: data.flowId,
         flowBeginTime: data.flowBeginTime,
         utmCampaign: data.utmCampaign,

--- a/tests/lib/account.js
+++ b/tests/lib/account.js
@@ -234,6 +234,7 @@ define([
               keys: true,
               metricsContext: {
                 deviceId: '0123456789abcdef0123456789abcdef',
+                entrypoint: 'mock-entrypoint',
                 flowBeginTime: 1480615985437,
                 flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
                 utmCampaign: 'mock-campaign',

--- a/tests/lib/metricsContext.js
+++ b/tests/lib/metricsContext.js
@@ -34,6 +34,7 @@ define([
 
       assert.deepEqual(metricsContext.marshall(input), {
         deviceId: input.deviceId,
+        entrypoint: 'menupanel',
         flowBeginTime: input.flowBeginTime,
         flowId: input.flowId,
         utmCampaign: 'foo',

--- a/tests/lib/recoveryCodes.js
+++ b/tests/lib/recoveryCodes.js
@@ -32,7 +32,7 @@ define([
         RequestMocks = env.RequestMocks;
         metricsContext = {
           flowBeginTime: Date.now(),
-            flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
         };
 
         return accountHelper.newVerifiedAccount()

--- a/tests/lib/session.js
+++ b/tests/lib/session.js
@@ -292,8 +292,12 @@ define([
             var options = {
               keys: true,
               metricsContext: {
-                utmTerm: 'search term',
-                utmContent: 'exciting content for you!'
+                entrypoint: 'mock-entrypoint',
+                utmCampaign: 'mock-utm-campaign',
+                utmContent: 'mock-utm-content',
+                utmMedium: 'mock-utm-medium',
+                utmSource: 'mock-utm-source',
+                utmTerm: 'mock-utm-term'
               },
               originalLoginEmail: email.toUpperCase(),
               reason: 'password_change',
@@ -327,8 +331,7 @@ define([
                   assert.equal(payload.resume, options.resume);
                   assert.equal(payload.service, options.service);
                   assert.equal(payload.verificationMethod, options.verificationMethod);
-                },
-                assert.notOk
+                }
               );
           });
       });


### PR DESCRIPTION
Related to mozilla/fxa-auth-server#2917.

Adds `entrypoint` to the metricsContext payload, which was added to the auth server in mozilla/fxa-auth-server#2929 and shipped in train 131. Also includes a secondary fix for the tests, where new validation in the auth server was causing them to fail.

@mozilla/fxa-devs r?